### PR TITLE
fix reentrancy bug

### DIFF
--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -89,7 +89,7 @@ contract WasabiLongPool is BaseWasabiPool {
         bool _unwrapWETH,
         ClosePositionRequest calldata _request,
         Signature calldata _signature
-    ) external payable nonReentrant {
+    ) external payable {
         _validateSignature(_request.hash(), _signature);
         if (_request.position.trader != msg.sender) revert SenderNotTrader();
         if (_request.expiration < block.timestamp) revert OrderExpired();
@@ -182,7 +182,7 @@ contract WasabiLongPool is BaseWasabiPool {
         uint256 _interest,
         Position calldata _position,
         FunctionCallData[] calldata _swapFunctions
-    ) internal returns(uint256 payout, uint256 principalRepaid, uint256 interestPaid, uint256 feeAmount) {
+    ) internal nonReentrant returns(uint256 payout, uint256 principalRepaid, uint256 interestPaid, uint256 feeAmount) {
         if (positions[_position.id] != _position.hash()) revert InvalidPosition();
         if (_swapFunctions.length == 0) revert SwapFunctionNeeded();
 


### PR DESCRIPTION
Fixes a reentrancy bug that only occurs if the protocol decides to unwrap on liquidation. (Noted that in the zelliac audit this is currently not the case) 

1) trader opens a position as a contract instead of EOA 2) liquidator liquidates position unwrapping WETH and sending ETH to trader contract 3) trader contract re-enters before `positions` is updated and closes the position again by calling `closePosition` which would finally trigger the first nonReentrant check at the parent function