### PR TITLE
Mark closed positions with magic byes

### DIFF
--- a/contracts/BaseWasabiPool.sol
+++ b/contracts/BaseWasabiPool.sol
@@ -37,6 +37,9 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
     /// @dev the base tokens
     mapping(address => bool) public baseTokens;
 
+    /// @dev magic bytes for closed position
+    bytes32 internal constant CLOSED_POSITION_HASH = bytes32(uint256(1));
+
     /**
      * @dev Checks if the caller has the correct role
      */

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -221,7 +221,7 @@ contract WasabiLongPool is BaseWasabiPool {
             closeFee
         );
 
-        delete positions[_position.id];
+        positions[_position.id] = CLOSED_POSITION_HASH;
     }
 
     /// @dev Closes a given position
@@ -294,6 +294,6 @@ contract WasabiLongPool is BaseWasabiPool {
             closeAmounts
         );
 
-        delete positions[_position.id];
+        positions[_position.id] = CLOSED_POSITION_HASH;
     }
 }

--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -221,7 +221,7 @@ contract WasabiShortPool is BaseWasabiPool {
             closeFee
         );
 
-        delete positions[_position.id];
+        positions[_position.id] = CLOSED_POSITION_HASH;
     }
 
     /// @dev Closes a given position
@@ -298,7 +298,7 @@ contract WasabiShortPool is BaseWasabiPool {
             closeAmounts
         );
 
-        delete positions[_position.id];
+        positions[_position.id] = CLOSED_POSITION_HASH;
     }
 
     /// @dev Validates if the value is deviated x percentage from the value to compare

--- a/test/WasabiLongPool_validations.test.ts
+++ b/test/WasabiLongPool_validations.test.ts
@@ -57,6 +57,19 @@ describe("WasabiLongPool - Validations Test", function () {
                 .to.be.rejectedWith("SwapFunctionNeeded", "Cannot open positions without swap functions");
         });
 
+        it("Cannot Reuse Signature", async function () {
+            const { wasabiLongPool, createSignedClosePositionRequest, sendDefaultOpenPositionRequest, user1 } = await loadFixture(deployLongPoolMockEnvironment);
+
+            const {position} = await sendDefaultOpenPositionRequest();
+
+            const {request, signature } = await createSignedClosePositionRequest({ position });
+
+            await wasabiLongPool.write.closePosition([true, request, signature], { account: user1.account });
+
+            await expect(sendDefaultOpenPositionRequest())
+                .to.be.rejectedWith("PositionAlreadyTaken", "Cannot open position if position is it was opened before");
+        });
+
         it("OrderExpired", async function () {
             const { publicClient, wasabiLongPool, user1, owner, openPositionRequest, totalAmountIn, contractName, orderSigner } = await loadFixture(deployLongPoolMockEnvironment);
 

--- a/test/WasabiLongPool_validations.test.ts
+++ b/test/WasabiLongPool_validations.test.ts
@@ -57,7 +57,7 @@ describe("WasabiLongPool - Validations Test", function () {
                 .to.be.rejectedWith("SwapFunctionNeeded", "Cannot open positions without swap functions");
         });
 
-        it("Cannot Reuse Signature", async function () {
+        it.only("Cannot Reuse Signature", async function () {
             const { wasabiLongPool, createSignedClosePositionRequest, sendDefaultOpenPositionRequest, user1 } = await loadFixture(deployLongPoolMockEnvironment);
 
             const {position} = await sendDefaultOpenPositionRequest();
@@ -68,6 +68,9 @@ describe("WasabiLongPool - Validations Test", function () {
 
             await expect(sendDefaultOpenPositionRequest())
                 .to.be.rejectedWith("PositionAlreadyTaken", "Cannot open position if position is it was opened before");
+
+            const positionHash = await wasabiLongPool.read.positions([position.id]);
+            expect(positionHash).to.equal(1n);
         });
 
         it("OrderExpired", async function () {


### PR DESCRIPTION
Currently, if the positions are closed before the signature expiration, then they may be able to reopen them unexpectedly.

When a position is closed, instead of deleting, mark the position with magic bytes