### PR TITLE
Allow depositing payouts into vault

### DIFF
--- a/contracts/BaseWasabiPool.sol
+++ b/contracts/BaseWasabiPool.sol
@@ -197,6 +197,9 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
                 IWasabiVault vault = isLongPool 
                     ? getVault(address(token)) 
                     : addressProvider.getVault(address(token));
+                if (token.allowance(address(this), address(vault)) < _closeAmounts.payout) {
+                    token.approve(address(vault), type(uint256).max);
+                }
                 vault.deposit(_closeAmounts.payout, _trader);
             } else {
                 token.safeTransfer(_trader, _closeAmounts.payout);

--- a/contracts/BaseWasabiPool.sol
+++ b/contracts/BaseWasabiPool.sol
@@ -169,8 +169,10 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
 
             if (_depositToVault) {
                 if (_closeAmounts.payout != 0) {
-                    // TODO: change this so the short pool can also get the WETH vault address
-                    getVault(address(token)).depositEth{value: _closeAmounts.payout}(_trader);
+                    IWasabiVault vault = isLongPool 
+                        ? getVault(address(token)) 
+                        : addressProvider.getVault(address(token));
+                    vault.depositEth{value: _closeAmounts.payout}(_trader);
                 }
             } else {
                 PerpUtils.payETH(_closeAmounts.payout, _trader);
@@ -187,8 +189,10 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
 
             if (_closeAmounts.payout != 0) {
                 if (_depositToVault) {
-                    // TODO: change this so the short pool can also get the WETH vault address
-                    getVault(address(token)).deposit(_closeAmounts.payout, _trader);
+                    IWasabiVault vault = isLongPool 
+                        ? getVault(address(token)) 
+                        : addressProvider.getVault(address(token));
+                    vault.deposit(_closeAmounts.payout, _trader);
                 } else {
                     SafeERC20.safeTransfer(token, _trader, _closeAmounts.payout);
                 }

--- a/contracts/IWasabiPerps.sol
+++ b/contracts/IWasabiPerps.sol
@@ -92,6 +92,13 @@ interface IWasabiPerps {
     /// @dev Emitted when a new vault is created
     event NewVault(address indexed pool, address indexed asset, address vault);
 
+    /// @dev Flag specifying whether to send WETH to the trader, send ETH to the trader, or deposit WETH to the vault
+    enum PayoutType {
+        WRAPPED,
+        UNWRAPPED,
+        VAULT_DEPOSIT
+    }
+
     /// @dev Defines a function call
     struct FunctionCallData {
         address to;
@@ -207,51 +214,23 @@ interface IWasabiPerps {
     ) external payable;
 
     /// @dev Closes a position
-    /// @param _unwrapWETH whether to unwrap WETH or not
+    /// @param _payoutType whether to send WETH to the trader, send ETH, or deposit WETH to the vault
     /// @param _request the request to close a position
     /// @param _signature the signature of the request
     function closePosition(
-        bool _unwrapWETH,
+        PayoutType _payoutType,
         ClosePositionRequest calldata _request,
         Signature calldata _signature
     ) external payable;
 
     /// @dev Closes a position
-    /// @param _unwrapWETH whether to unwrap WETH or not
-    /// @param _depositToVault whether to deposit the payout to the vault or not
-    /// @param _request the request to close a position
-    /// @param _signature the signature of the request
-    function closePosition(
-        bool _unwrapWETH,
-        bool _depositToVault,
-        ClosePositionRequest calldata _request,
-        Signature calldata _signature
-    ) external payable;
-
-    /// @dev Closes a position
-    /// @param _unwrapWETH whether to unwrap WETH or not
+    /// @param _payoutType whether to send WETH to the trader, send ETH, or deposit WETH to the vault
     /// @param _request the request to close a position
     /// @param _signature the signature of the request, signed by the ORDER_SIGNER_ROLE
     /// @param _order the order to close the position
     /// @param _orderSignature the signature of the order, signed by the owner of the position
     function closePosition(
-        bool _unwrapWETH,
-        ClosePositionRequest calldata _request,
-        Signature calldata _signature,
-        ClosePositionOrder calldata _order,
-        Signature calldata _orderSignature
-    ) external payable;
-
-    /// @dev Closes a position
-    /// @param _unwrapWETH whether to unwrap WETH or not
-    /// @param _depositToVault whether to deposit the payout to the vault or not
-    /// @param _request the request to close a position
-    /// @param _signature the signature of the request, signed by the ORDER_SIGNER_ROLE
-    /// @param _order the order to close the position
-    /// @param _orderSignature the signature of the order, signed by the owner of the position
-    function closePosition(
-        bool _unwrapWETH,
-        bool _depositToVault,
+        PayoutType _payoutType,
         ClosePositionRequest calldata _request,
         Signature calldata _signature,
         ClosePositionOrder calldata _order,
@@ -259,26 +238,12 @@ interface IWasabiPerps {
     ) external payable;
 
     /// @dev Liquidates a position
-    /// @param _unwrapWETH whether to unwrap WETH or not
+    /// @param _payoutType whether to send WETH to the trader, send ETH, or deposit WETH to the vault
     /// @param _interest the interest to be paid
     /// @param _position the position to liquidate
     /// @param _swapFunctions the swap functions to use to liquidate the position
     function liquidatePosition(
-        bool _unwrapWETH,
-        uint256 _interest,
-        Position calldata _position,
-        FunctionCallData[] calldata _swapFunctions
-    ) external payable;
-
-    /// @dev Liquidates a position
-    /// @param _unwrapWETH whether to unwrap WETH or not
-    /// @param _depositToVault whether to deposit the payout to the vault or not
-    /// @param _interest the interest to be paid
-    /// @param _position the position to liquidate
-    /// @param _swapFunctions the swap functions to use to liquidate the position
-    function liquidatePosition(
-        bool _unwrapWETH,
-        bool _depositToVault,
+        PayoutType _payoutType,
         uint256 _interest,
         Position calldata _position,
         FunctionCallData[] calldata _swapFunctions

--- a/contracts/IWasabiPerps.sol
+++ b/contracts/IWasabiPerps.sol
@@ -218,12 +218,40 @@ interface IWasabiPerps {
 
     /// @dev Closes a position
     /// @param _unwrapWETH whether to unwrap WETH or not
+    /// @param _depositToVault whether to deposit the payout to the vault or not
+    /// @param _request the request to close a position
+    /// @param _signature the signature of the request
+    function closePosition(
+        bool _unwrapWETH,
+        bool _depositToVault,
+        ClosePositionRequest calldata _request,
+        Signature calldata _signature
+    ) external payable;
+
+    /// @dev Closes a position
+    /// @param _unwrapWETH whether to unwrap WETH or not
     /// @param _request the request to close a position
     /// @param _signature the signature of the request, signed by the ORDER_SIGNER_ROLE
     /// @param _order the order to close the position
     /// @param _orderSignature the signature of the order, signed by the owner of the position
     function closePosition(
         bool _unwrapWETH,
+        ClosePositionRequest calldata _request,
+        Signature calldata _signature,
+        ClosePositionOrder calldata _order,
+        Signature calldata _orderSignature
+    ) external payable;
+
+    /// @dev Closes a position
+    /// @param _unwrapWETH whether to unwrap WETH or not
+    /// @param _depositToVault whether to deposit the payout to the vault or not
+    /// @param _request the request to close a position
+    /// @param _signature the signature of the request, signed by the ORDER_SIGNER_ROLE
+    /// @param _order the order to close the position
+    /// @param _orderSignature the signature of the order, signed by the owner of the position
+    function closePosition(
+        bool _unwrapWETH,
+        bool _depositToVault,
         ClosePositionRequest calldata _request,
         Signature calldata _signature,
         ClosePositionOrder calldata _order,
@@ -237,6 +265,20 @@ interface IWasabiPerps {
     /// @param _swapFunctions the swap functions to use to liquidate the position
     function liquidatePosition(
         bool _unwrapWETH,
+        uint256 _interest,
+        Position calldata _position,
+        FunctionCallData[] calldata _swapFunctions
+    ) external payable;
+
+    /// @dev Liquidates a position
+    /// @param _unwrapWETH whether to unwrap WETH or not
+    /// @param _depositToVault whether to deposit the payout to the vault or not
+    /// @param _interest the interest to be paid
+    /// @param _position the position to liquidate
+    /// @param _swapFunctions the swap functions to use to liquidate the position
+    function liquidatePosition(
+        bool _unwrapWETH,
+        bool _depositToVault,
         uint256 _interest,
         Position calldata _position,
         FunctionCallData[] calldata _swapFunctions

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -92,7 +92,19 @@ contract WasabiLongPool is BaseWasabiPool {
         Signature calldata _signature,
         ClosePositionOrder calldata _order,
         Signature calldata _orderSignature // signed by trader
-    ) external payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
+    ) external payable {
+        closePosition(_unwrapWETH, false, _request, _signature, _order, _orderSignature);
+    }
+
+    /// @inheritdoc IWasabiPerps
+    function closePosition(
+        bool _unwrapWETH,
+        bool _depositToVault,
+        ClosePositionRequest calldata _request,
+        Signature calldata _signature,
+        ClosePositionOrder calldata _order,
+        Signature calldata _orderSignature // signed by trader
+    ) public payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
         if (_request.position.id != _order.positionId) revert InvalidOrder();
         if (_request.expiration < block.timestamp) revert OrderExpired();
         if (_order.expiration < block.timestamp) revert OrderExpired();
@@ -102,7 +114,7 @@ contract WasabiLongPool is BaseWasabiPool {
         _validateSignature(_request.hash(), _signature);
         
         CloseAmounts memory closeAmounts =
-            _closePositionInternal(_unwrapWETH, _request.interest, _request.position, _request.functionCallDataList, _order.executionFee, false);
+            _closePositionInternal(_unwrapWETH, _depositToVault, _request.interest, _request.position, _request.functionCallDataList, _order.executionFee, false);
 
         uint256 actualTakerAmount = closeAmounts.payout + closeAmounts.closeFee + closeAmounts.interestPaid + closeAmounts.principalRepaid;
 
@@ -134,13 +146,23 @@ contract WasabiLongPool is BaseWasabiPool {
         bool _unwrapWETH,
         ClosePositionRequest calldata _request,
         Signature calldata _signature
-    ) external payable nonReentrant {
+    ) external payable {
+        closePosition(_unwrapWETH, false, _request, _signature);
+    }
+
+    /// @inheritdoc IWasabiPerps
+    function closePosition(
+        bool _unwrapWETH,
+        bool _depositToVault,
+        ClosePositionRequest calldata _request,
+        Signature calldata _signature
+    ) public payable nonReentrant {
         _validateSignature(_request.hash(), _signature);
         _checkCanClosePosition(_request.position.trader);
         if (_request.expiration < block.timestamp) revert OrderExpired();
         
         CloseAmounts memory closeAmounts =
-            _closePositionInternal(_unwrapWETH, _request.interest, _request.position, _request.functionCallDataList, 0, false);
+            _closePositionInternal(_unwrapWETH, _depositToVault, _request.interest, _request.position, _request.functionCallDataList, 0, false);
 
         emit PositionClosed(
             _request.position.id,
@@ -158,9 +180,20 @@ contract WasabiLongPool is BaseWasabiPool {
         uint256 _interest,
         Position calldata _position,
         FunctionCallData[] calldata _swapFunctions
-    ) public override payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
+    ) public override payable {
+        liquidatePosition(_unwrapWETH, false, _interest, _position, _swapFunctions);
+    }
+
+    /// @inheritdoc IWasabiPerps
+    function liquidatePosition(
+        bool _unwrapWETH,
+        bool _depositToVault,
+        uint256 _interest,
+        Position calldata _position,
+        FunctionCallData[] calldata _swapFunctions
+    ) public payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
         CloseAmounts memory closeAmounts =
-            _closePositionInternal(_unwrapWETH, _interest, _position, _swapFunctions, 0, true);
+            _closePositionInternal(_unwrapWETH, _depositToVault, _interest, _position, _swapFunctions, 0, true);
         uint256 liquidationThreshold = _position.principal * 5 / 100;
         if (closeAmounts.payout + closeAmounts.liquidationFee > liquidationThreshold) revert LiquidationThresholdNotReached();
 
@@ -210,7 +243,7 @@ contract WasabiLongPool is BaseWasabiPool {
             0                           // liquidationFee
         );
 
-        _payCloseAmounts(true, weth, _position.trader, _closeAmounts);
+        _payCloseAmounts(true, false, weth, _position.trader, _closeAmounts);
 
         emit PositionClaimed(
             _position.id,
@@ -226,6 +259,7 @@ contract WasabiLongPool is BaseWasabiPool {
 
     /// @dev Closes a given position
     /// @param _unwrapWETH flag indicating if the payout should be unwrapped to ETH
+    /// @param _depositToVault flag indicating if the payout should be deposited to the vault
     /// @param _interest the interest amount to be paid
     /// @param _position the position
     /// @param _swapFunctions the swap functions
@@ -234,6 +268,7 @@ contract WasabiLongPool is BaseWasabiPool {
     /// @return closeAmounts the close amounts
     function _closePositionInternal(
         bool _unwrapWETH,
+        bool _depositToVault,
         uint256 _interest,
         Position calldata _position,
         FunctionCallData[] calldata _swapFunctions,
@@ -289,6 +324,7 @@ contract WasabiLongPool is BaseWasabiPool {
 
         _payCloseAmounts(
             _unwrapWETH,
+            _depositToVault,
             token,
             _position.trader,
             closeAmounts

--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -84,24 +84,12 @@ contract WasabiShortPool is BaseWasabiPool {
 
     /// @inheritdoc IWasabiPerps
     function closePosition(
-        bool _unwrapWETH,
+        PayoutType _payoutType,
         ClosePositionRequest calldata _request,
         Signature calldata _signature,
         ClosePositionOrder calldata _order,
         Signature calldata _orderSignature // signed by trader
-    ) external payable {
-        closePosition(_unwrapWETH, false, _request, _signature, _order, _orderSignature);
-    }
-
-    /// @inheritdoc IWasabiPerps
-    function closePosition(
-        bool _unwrapWETH,
-        bool _depositToVault,
-        ClosePositionRequest calldata _request,
-        Signature calldata _signature,
-        ClosePositionOrder calldata _order,
-        Signature calldata _orderSignature // signed by trader
-    ) public payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
+    ) external payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
         if (_request.position.id != _order.positionId) revert InvalidOrder();
         if (_order.expiration < block.timestamp) revert OrderExpired();
         if (_request.expiration < block.timestamp) revert OrderExpired();
@@ -110,7 +98,7 @@ contract WasabiShortPool is BaseWasabiPool {
         _validateSignature(_request.hash(), _signature);
 
         CloseAmounts memory closeAmounts =
-            _closePositionInternal(_unwrapWETH, _depositToVault, _request.interest, _request.position, _request.functionCallDataList, _order.executionFee, false);
+            _closePositionInternal(_payoutType, _request.interest, _request.position, _request.functionCallDataList, _order.executionFee, false);
 
         uint256 actualMakerAmount = closeAmounts.collateralSpent;
         uint256 actualTakerAmount = closeAmounts.interestPaid + closeAmounts.principalRepaid;
@@ -147,26 +135,16 @@ contract WasabiShortPool is BaseWasabiPool {
 
     /// @inheritdoc IWasabiPerps
     function closePosition(
-        bool _unwrapWETH,
+        PayoutType _payoutType,
         ClosePositionRequest calldata _request,
         Signature calldata _signature
-    ) external payable {
-        closePosition(_unwrapWETH, false, _request, _signature);
-    }
-
-    /// @inheritdoc IWasabiPerps
-    function closePosition(
-        bool _unwrapWETH,
-        bool _depositToVault,
-        ClosePositionRequest calldata _request,
-        Signature calldata _signature
-    ) public payable nonReentrant {
+    ) external payable nonReentrant {
         _validateSignature(_request.hash(), _signature);
         _checkCanClosePosition(_request.position.trader);
         if (_request.expiration < block.timestamp) revert OrderExpired();
         
         CloseAmounts memory closeAmounts =
-            _closePositionInternal(_unwrapWETH, _depositToVault, _request.interest, _request.position, _request.functionCallDataList, 0, false);
+            _closePositionInternal(_payoutType, _request.interest, _request.position, _request.functionCallDataList, 0, false);
 
         emit PositionClosed(
             _request.position.id,
@@ -180,24 +158,13 @@ contract WasabiShortPool is BaseWasabiPool {
 
     /// @inheritdoc IWasabiPerps
     function liquidatePosition(
-        bool _unwrapWETH,
+        PayoutType _payoutType,
         uint256 _interest,
         Position calldata _position,
         FunctionCallData[] calldata _swapFunctions
-    ) public override payable {
-        liquidatePosition(_unwrapWETH, false, _interest, _position, _swapFunctions);
-    }
-
-    /// @inheritdoc IWasabiPerps
-    function liquidatePosition(
-        bool _unwrapWETH,
-        bool _depositToVault,
-        uint256 _interest,
-        Position calldata _position,
-        FunctionCallData[] calldata _swapFunctions
-    ) public payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
+    ) external payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
         CloseAmounts memory closeAmounts =
-            _closePositionInternal(_unwrapWETH, _depositToVault, _interest, _position, _swapFunctions, 0, true);
+            _closePositionInternal(_payoutType, _interest, _position, _swapFunctions, 0, true);
         uint256 liquidationThreshold = _position.collateralAmount * 5 / 100;
         if (closeAmounts.payout + closeAmounts.liquidationFee > liquidationThreshold) revert LiquidationThresholdNotReached();
 
@@ -236,8 +203,7 @@ contract WasabiShortPool is BaseWasabiPool {
         );
 
         _payCloseAmounts(
-            true,
-            false,
+            PayoutType.UNWRAPPED,
             IWETH(_position.collateralCurrency),
             _position.trader,
             _closeAmounts
@@ -259,8 +225,7 @@ contract WasabiShortPool is BaseWasabiPool {
     }
 
     /// @dev Closes a given position
-    /// @param _unwrapWETH flag indicating if the payout should be unwrapped to ETH
-    /// @param _depositToVault flag indicating if the payout should be deposited to the vault
+    /// @param _payoutType whether to send WETH to the trader, send ETH, or deposit WETH to the vault
     /// @param _interest the interest amount to be paid
     /// @param _position the position
     /// @param _swapFunctions the swap functions
@@ -268,8 +233,7 @@ contract WasabiShortPool is BaseWasabiPool {
     /// @param _isLiquidation flag indicating if the close is a liquidation
     /// @return closeAmounts the close amounts
     function _closePositionInternal(
-        bool _unwrapWETH,
-        bool _depositToVault,
+        PayoutType _payoutType,
         uint256 _interest,
         Position calldata _position,
         FunctionCallData[] calldata _swapFunctions,
@@ -328,8 +292,7 @@ contract WasabiShortPool is BaseWasabiPool {
         );
 
         _payCloseAmounts(
-            _unwrapWETH,
-            _depositToVault,
+            _payoutType,
             collateralToken,
             _position.trader,
             closeAmounts

--- a/contracts/addressProvider/AddressProvider.sol
+++ b/contracts/addressProvider/AddressProvider.sol
@@ -5,16 +5,22 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./IAddressProvider.sol";
 import "../debt/IDebtController.sol";
+import "../vaults/IWasabiVault.sol";
 
 contract AddressProvider is Ownable, IAddressProvider {
     error InvalidAddress();
     error InvalidLiquidationFee();
+    error InvalidVault();
+    error VaultAlreadyExists();
 
     IDebtController public debtController;
     address public feeReceiver;
     address public immutable wethAddress;
     address public liquidationFeeReceiver;
     uint256 public liquidationFeeBps;
+
+    /// @dev the ERC20 vaults
+    mapping(address => address) public vaults;
 
     constructor(
         IDebtController _debtController,
@@ -64,6 +70,26 @@ contract AddressProvider is Ownable, IAddressProvider {
         return wethAddress;
     }
 
+    /// @inheritdoc IAddressProvider
+    function getLiquidationFeeBps() external view override returns (uint256) {
+        return liquidationFeeBps;
+    }
+
+    /// @inheritdoc IAddressProvider
+    function getVault(address _asset) public view returns (IWasabiVault) {
+        if (_asset == address(0)) {
+            _asset = wethAddress;
+        }
+        if (vaults[_asset] == address(0)) revert InvalidVault();
+        return IWasabiVault(vaults[_asset]);
+    }
+
+    /// @inheritdoc IAddressProvider
+    function addVault(IWasabiVault _vault) external onlyOwner {
+        if (vaults[_vault.asset()] != address(0)) revert VaultAlreadyExists();
+        vaults[_vault.asset()] = address(_vault);
+    }
+
     /// @dev sets the debt controller
     /// @param _debtController the debt controller
     function setDebtController(IDebtController _debtController) external onlyOwner {
@@ -89,10 +115,5 @@ contract AddressProvider is Ownable, IAddressProvider {
     function setLiquidationFeeBps(uint256 _liquidationFeeBps) external onlyOwner {
         if (_liquidationFeeBps > 500) revert InvalidLiquidationFee();
         liquidationFeeBps = _liquidationFeeBps;
-    }
-
-    /// @inheritdoc IAddressProvider
-    function getLiquidationFeeBps() external view override returns (uint256) {
-        return liquidationFeeBps;
     }
 }

--- a/contracts/addressProvider/IAddressProvider.sol
+++ b/contracts/addressProvider/IAddressProvider.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.23;
 
 import "../debt/IDebtController.sol";
+import "../vaults/IWasabiVault.sol";
 
 interface IAddressProvider {
 
@@ -19,4 +20,10 @@ interface IAddressProvider {
 
     /// @dev Returns the liquidation fee bps
     function getLiquidationFeeBps() external view returns (uint256);
+
+    /// @dev Returns the vault address for the given asset
+    function getVault(address _asset) external view returns (IWasabiVault);
+
+    /// @dev Adds a new vault
+    function addVault(IWasabiVault _vault) external;
 }

--- a/contracts/vaults/IWasabiVault.sol
+++ b/contracts/vaults/IWasabiVault.sol
@@ -10,6 +10,9 @@ interface IWasabiVault is IERC4626 {
     error InvalidEthAmount();
     error InvalidAmount();
 
+    /// @dev Deposits ETH into the vault (only WETH vault)
+    function depositEth(address receiver) external payable returns (uint256);
+
     /// @dev Records an interest payment
     function recordInterestEarned(uint256 _interestAmount) external;
 

--- a/contracts/vaults/WasabiVault.sol
+++ b/contracts/vaults/WasabiVault.sol
@@ -108,7 +108,9 @@ contract WasabiVault is IWasabiVault, UUPSUpgradeable, OwnableUpgradeable, ERC46
     ) internal virtual override nonReentrant {
         if (assets == 0 || shares == 0) revert InvalidAmount();
 
-        SafeERC20.safeTransferFrom(IERC20(asset()), caller, address(pool), assets);
+        if (caller != address(pool)) {
+            SafeERC20.safeTransferFrom(IERC20(asset()), caller, address(pool), assets);
+        }
 
         _mint(receiver, shares);
         totalAssetValue += assets;

--- a/test/WasabiLongPool_tpslFlow.test.ts
+++ b/test/WasabiLongPool_tpslFlow.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { parseEther } from "viem";
 import { expect } from "chai";
-import { ClosePositionRequest, OrderType } from "./utils/PerpStructUtils";
+import { ClosePositionRequest, OrderType, PayoutType } from "./utils/PerpStructUtils";
 import { deployLongPoolMockEnvironment } from "./fixtures";
 import { getBalance } from "./utils/StateUtils";
 import { getApproveAndSwapFunctionCallDataExact } from "./utils/SwapUtils";
@@ -40,7 +40,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({address: feeReceiver });
 
             const hash = await wasabiLongPool.write.closePosition(
-                [true, request, signature, order, orderSignature], {account: liquidator.account}
+                [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
             );
 
             const traderBalanceAfter = await publicClient.getBalance({address: user1.account.address });
@@ -97,7 +97,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({address: feeReceiver });
 
             const hash = await wasabiLongPool.write.closePosition(
-                [true, request, signature, order, orderSignature], {account: liquidator.account}
+                [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
             );
 
             const traderBalanceAfter = await publicClient.getBalance({address: user1.account.address });
@@ -152,7 +152,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("PriceTargetNotReached");
             });
 
@@ -180,7 +180,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("OrderExpired");
             });
 
@@ -208,7 +208,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 await mockSwap.write.setPrice([uPPG.address, wethAddress, initialPrice * 2n]); // Price doubled
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("OrderExpired");
             });
 
@@ -236,7 +236,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InvalidOrder");
             });
 
@@ -261,7 +261,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InvalidOrder");
             });
 
@@ -289,7 +289,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("TooMuchCollateralSpent");
             });
 
@@ -317,7 +317,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InvalidSignature");
             });
 
@@ -345,7 +345,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, orderSignature, order, orderSignature], {account: liquidator.account} // Wrong signature
+                    [PayoutType.UNWRAPPED, request, orderSignature, order, orderSignature], {account: liquidator.account} // Wrong signature
                 )).to.be.rejectedWith("InvalidSignature");
             });
 
@@ -373,7 +373,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account} // Wrong signer
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account} // Wrong signer
                 )).to.be.rejectedWith("InvalidSignature");
             });
         });
@@ -408,7 +408,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({address: feeReceiver });
 
             const hash = await wasabiLongPool.write.closePosition(
-                [true, request, signature, order, orderSignature], {account: liquidator.account}
+                [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
             );
 
             const traderBalanceAfter = await publicClient.getBalance({address: user1.account.address });
@@ -465,7 +465,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({address: feeReceiver });
 
             const hash = await wasabiLongPool.write.closePosition(
-                [true, request, signature, order, orderSignature], {account: liquidator.account}
+                [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
             );
 
             const traderBalanceAfter = await publicClient.getBalance({address: user1.account.address });
@@ -519,7 +519,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("PriceTargetNotReached");
             });
 
@@ -553,7 +553,7 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
                 const signature = await signClosePositionRequest(orderSigner, contractName, wasabiLongPool.address, request);
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InsufficientPrincipalRepaid");
             });
         });

--- a/test/WasabiShortPool_tpslFlow.test.ts
+++ b/test/WasabiShortPool_tpslFlow.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import {encodeFunctionData, zeroAddress, parseEther} from "viem";
 import { expect } from "chai";
-import { Position, OrderType, getEventPosition, getValueWithoutFee, ClosePositionRequest } from "./utils/PerpStructUtils";
+import { Position, OrderType, PayoutType, getValueWithoutFee, ClosePositionRequest } from "./utils/PerpStructUtils";
 import { getApproveAndSwapFunctionCallData, getApproveAndSwapFunctionCallDataExact } from "./utils/SwapUtils";
 import { deployShortPoolMockEnvironment } from "./fixtures";
 import { getBalance, takeBalanceSnapshot } from "./utils/StateUtils";
@@ -42,7 +42,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({ address: feeReceiver });
         
             const hash = await wasabiShortPool.write.closePosition(
-                [true, request, signature, order, orderSignature], {account: liquidator.account}
+                [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
             );
 
             const tokenBalancesAfter = await takeBalanceSnapshot(publicClient, uPPG.address, wasabiShortPool.address);
@@ -106,7 +106,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({ address: feeReceiver });
         
             const hash = await wasabiShortPool.write.closePosition(
-                [true, request, signature, order, orderSignature], {account: liquidator.account}
+                [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
             );
 
             const tokenBalancesAfter = await takeBalanceSnapshot(publicClient, uPPG.address, wasabiShortPool.address);
@@ -167,7 +167,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("PriceTargetNotReached");
             });
 
@@ -195,7 +195,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("OrderExpired");
             });
 
@@ -223,7 +223,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 await mockSwap.write.setPrice([uPPG.address, wethAddress, initialPrice / 2n]); // Price halved
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("OrderExpired");
             });
 
@@ -251,7 +251,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InvalidOrder");
             });
 
@@ -279,7 +279,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InvalidOrder");
             });
 
@@ -307,7 +307,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InvalidSignature");
             });
 
@@ -335,7 +335,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 const { request } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, orderSignature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, orderSignature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InvalidSignature");
             });
         });
@@ -372,7 +372,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({ address: feeReceiver });
         
             const hash = await wasabiShortPool.write.closePosition(
-                [true, request, signature, order, orderSignature], {account: liquidator.account}
+                [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
             );
 
             const tokenBalancesAfter = await takeBalanceSnapshot(publicClient, uPPG.address, wasabiShortPool.address);
@@ -436,7 +436,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({ address: feeReceiver });
         
             const hash = await wasabiShortPool.write.closePosition(
-                [true, request, signature, order, orderSignature], {account: liquidator.account}
+                [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
             );
 
             const tokenBalancesAfter = await takeBalanceSnapshot(publicClient, uPPG.address, wasabiShortPool.address);
@@ -495,7 +495,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 const { request, signature } = await createSignedClosePositionRequest({position});
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("PriceTargetNotReached");
             });
 
@@ -529,7 +529,7 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
                 const signature = await signClosePositionRequest(orderSigner, contractName, wasabiShortPool.address, request);
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [true, request, signature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InsufficientPrincipalRepaid");
             });
         });

--- a/test/WasabiShortPool_tradeFlow.test.ts
+++ b/test/WasabiShortPool_tradeFlow.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { expect } from "chai";
 import { getAddress, parseEther, maxUint256, zeroAddress } from "viem";
-import { getValueWithoutFee } from "./utils/PerpStructUtils";
+import { PayoutType } from "./utils/PerpStructUtils";
 import { getApproveAndSwapExactlyOutFunctionCallData, getApproveAndSwapFunctionCallData } from "./utils/SwapUtils";
 import { deployShortPoolMockEnvironment, deployWasabiShortPool } from "./fixtures";
 import { getBalance, takeBalanceSnapshot } from "./utils/StateUtils";
@@ -48,7 +48,7 @@ describe("WasabiShortPool - Trade Flow Test", function () {
             const userBalanceBefore = await publicClient.getBalance({ address: user1.account.address });
             const feeReceiverBalanceBefore = await publicClient.getBalance({ address: feeReceiver });
         
-            const hash = await wasabiShortPool.write.closePosition([true, request, signature], { account: user1.account });
+            const hash = await wasabiShortPool.write.closePosition([PayoutType.UNWRAPPED, request, signature], { account: user1.account });
 
             const tokenBalancesAfter = await takeBalanceSnapshot(publicClient, uPPG.address, wasabiShortPool.address);
             const balancesAfter = await takeBalanceSnapshot(publicClient, wethAddress, user1.account.address, wasabiShortPool.address, feeReceiver);
@@ -103,7 +103,7 @@ describe("WasabiShortPool - Trade Flow Test", function () {
             const userBalanceBefore = await publicClient.getBalance({ address: user1.account.address });
             const feeReceiverBalanceBefore = await publicClient.getBalance({ address: feeReceiver });
         
-            const hash = await wasabiShortPool.write.closePosition([true, request, signature], { account: user1.account });
+            const hash = await wasabiShortPool.write.closePosition([PayoutType.UNWRAPPED, request, signature], { account: user1.account });
 
             const tokenBalancesAfter = await takeBalanceSnapshot(publicClient, uPPG.address, wasabiShortPool.address);
             const balancesAfter = await takeBalanceSnapshot(publicClient, wethAddress, user1.account.address, wasabiShortPool.address, feeReceiver);
@@ -158,7 +158,7 @@ describe("WasabiShortPool - Trade Flow Test", function () {
                 position.collateralAmount,
                 position.principal + maxInterest);
 
-            await expect(wasabiShortPool.write.liquidatePosition([true, maxInterest, position, functionCallDataList], { account: liquidator.account }))
+            await expect(wasabiShortPool.write.liquidatePosition([PayoutType.UNWRAPPED, maxInterest, position, functionCallDataList], { account: liquidator.account }))
                 .to.be.rejectedWith("LiquidationThresholdNotReached", "Cannot liquidate position if liquidation price is not reached");
 
             // Liquidate Position
@@ -171,7 +171,7 @@ describe("WasabiShortPool - Trade Flow Test", function () {
             const feeReceiverBalanceBefore = await publicClient.getBalance({ address: feeReceiver });
             const liquidationFeeReceiverBalanceBefore = await publicClient.getBalance({address: liquidationFeeReceiver });    
 
-            const hash = await wasabiShortPool.write.liquidatePosition([true, maxInterest, position, functionCallDataList], { account: liquidator.account });
+            const hash = await wasabiShortPool.write.liquidatePosition([PayoutType.UNWRAPPED, maxInterest, position, functionCallDataList], { account: liquidator.account });
 
             const tokenBalancesAfter = await takeBalanceSnapshot(publicClient, uPPG.address, wasabiShortPool.address);
             const balancesAfter = await takeBalanceSnapshot(publicClient, wethAddress, user1.account.address, wasabiShortPool.address, feeReceiver, liquidationFeeReceiver);
@@ -230,7 +230,7 @@ describe("WasabiShortPool - Trade Flow Test", function () {
             console.log('liquidationPrice', liquidationPrice.toString());
             await mockSwap.write.setPrice([wethAddress, uPPG.address, liquidationPrice]); 
             
-            await wasabiShortPool.write.liquidatePosition([true, maxInterest, position, functionCallDataList], { account: liquidator.account });
+            await wasabiShortPool.write.liquidatePosition([PayoutType.UNWRAPPED, maxInterest, position, functionCallDataList], { account: liquidator.account });
     
             // Checks for no payout
             const events = await wasabiShortPool.getEvents.PositionLiquidated();

--- a/test/WasabiShortPool_validations.test.ts
+++ b/test/WasabiShortPool_validations.test.ts
@@ -1,7 +1,7 @@
 import { time, loadFixture } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { expect } from "chai";
 import { getAddress } from "viem";
-import { ClosePositionRequest, FunctionCallData, OpenPositionRequest, getFee } from "./utils/PerpStructUtils";
+import { ClosePositionRequest, FunctionCallData, OpenPositionRequest, getFee, PayoutType } from "./utils/PerpStructUtils";
 import { signClosePositionRequest, signOpenPositionRequest } from "./utils/SigningUtils";
 import { deployShortPoolMockEnvironment, deployWasabiShortPool } from "./fixtures";
 import { getApproveAndSwapFunctionCallData, getApproveAndSwapFunctionCallDataExact } from "./utils/SwapUtils";
@@ -94,7 +94,7 @@ describe("WasabiShortPool - Validations Test", function () {
             request.interest = interest * 105n / 100n; // Change interest to be invalid
             const signature = await signClosePositionRequest(orderSigner, contractName, wasabiShortPool.address, request);
 
-            await expect(wasabiShortPool.write.closePosition([true, request, signature], { account: user1.account }))
+            await expect(wasabiShortPool.write.closePosition([PayoutType.UNWRAPPED, request, signature], { account: user1.account }))
                 .to.be.rejectedWith("ValueDeviatedTooMuch", "Interest amount is invalid");
         });
 
@@ -114,7 +114,7 @@ describe("WasabiShortPool - Validations Test", function () {
             const request = await createClosePositionRequest({ position, interest });
             const signature = await signClosePositionRequest(orderSigner, contractName, wasabiShortPool.address, request);
 
-            await expect(wasabiShortPool.write.closePosition([true, request, signature], { account: user1.account }))
+            await expect(wasabiShortPool.write.closePosition([PayoutType.UNWRAPPED, request, signature], { account: user1.account }))
                 .to.be.rejectedWith("TooMuchCollateralSpent", "Too much collateral");
         });
 
@@ -133,7 +133,7 @@ describe("WasabiShortPool - Validations Test", function () {
             };
             const signature = await signClosePositionRequest(orderSigner, contractName, wasabiShortPool.address, request);
 
-            await expect(wasabiShortPool.write.closePosition([true, request, signature], { account: user1.account }))
+            await expect(wasabiShortPool.write.closePosition([PayoutType.UNWRAPPED, request, signature], { account: user1.account }))
                 .to.be.rejectedWith("InsufficientPrincipalRepaid");
         })
     });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -323,13 +323,13 @@ export async function deployWasabiLongPool() {
 export async function deployWasabiShortPool() {
     const perpManager = await deployPerpManager();
     const addressProviderFixture = await deployAddressProvider();
-    const {addressProvider} = addressProviderFixture;
+    const {addressProvider, weth} = addressProviderFixture;
 
     // Setup
     const [owner, user1, user2] = await hre.viem.getWalletClients();
     const publicClient = await hre.viem.getPublicClient();
 
-    // Deploy WasabiLongPool
+    // Deploy WasabiShortPool
     const contractName = "WasabiShortPool";
     const WasabiShortPool = await hre.ethers.getContractFactory(contractName);
     const proxy = await hre.upgrades.deployProxy(
@@ -343,6 +343,18 @@ export async function deployWasabiShortPool() {
 
     const wasabiShortPool = await hre.viem.getContractAt(contractName, address);
 
+    // Deploy WasabiLongPool (for USDC deposits on close)
+    const WasabiLongPool = await hre.ethers.getContractFactory("WasabiLongPool");
+    const longPoolAddress = 
+        await hre.upgrades.deployProxy(
+            WasabiLongPool,
+            [addressProviderFixture.addressProvider.address, perpManager.manager.address],
+            { kind: 'uups'}
+        )
+        .then(c => c.waitForDeployment())
+        .then(c => c.getAddress()).then(getAddress);
+    const wasabiLongPool = await hre.viem.getContractAt("WasabiLongPool", longPoolAddress);
+
     const uPPG = await hre.viem.deployContract("MockERC20", ["μPudgyPenguins", 'μPPG']);
     const usdc = await hre.viem.deployContract("USDC", []);
 
@@ -350,16 +362,30 @@ export async function deployWasabiShortPool() {
         wasabiShortPool.address, addressProvider.address, uPPG.address, "PPG Vault", "wuPPG");
     const {vault} = vaultFixture;
 
+    // Deploy WETH & USDC Vaults
+    const usdcVaultFixture = await deployVault(
+        wasabiLongPool.address, addressProvider.address, usdc.address, "USDC Vault", "wUSDC");
+    const usdcVault = usdcVaultFixture.vault;
+    const wethVaultFixture = await deployVault(
+        wasabiLongPool.address, addressProvider.address, weth.address, "WETH Vault", "wWETH");
+    const wethVault = wethVaultFixture.vault;
+
     const amount = parseEther("50");
     await uPPG.write.mint([amount]);
     await uPPG.write.approve([vault.address, amount]);
     await vault.write.deposit([amount, owner.account.address]);
     await wasabiShortPool.write.addVault([vault.address]);
+    await wasabiLongPool.write.addVault([wethVault.address]);
+    await wasabiLongPool.write.addVault([usdcVault.address]);
+    await addressProvider.write.addVault([vault.address]);
+    await addressProvider.write.addVault([wethVault.address]);
+    await addressProvider.write.addVault([usdcVault.address]);
 
     return {
         ...addressProviderFixture,
         ...perpManager,
         wasabiShortPool,
+        wasabiLongPool,
         owner,
         user1,
         user2,
@@ -367,6 +393,8 @@ export async function deployWasabiShortPool() {
         contractName,
         uPPG,
         usdc,
+        usdcVault,
+        wethVault,
     };
 }
 

--- a/test/utils/PerpStructUtils.ts
+++ b/test/utils/PerpStructUtils.ts
@@ -9,6 +9,12 @@ export enum OrderType {
   INVALID
 }
 
+export enum PayoutType {
+  WRAPPED,
+  UNWRAPPED,
+  VAULT_DEPOSIT
+}
+
 export type WithSignature<T> = {
   request: T;
   signature: Signature;


### PR DESCRIPTION
[WASAB-724](https://dkoda.atlassian.net/browse/WASAB-724)

Adds the option to deposit payouts into the appropriate vault on behalf of the trader on closing or liquidating a position.

Accomplished by replacing the `bool _unwrapWETH` flag with a `PayoutType` enum in the close/liquidate functions. Passing `PayoutType.WRAPPED` is equivalent to `_unwrapWETH = false`, and `PayoutType.UNWRAPPED` is equivalent to `_unwrapWETH = true`. `PayoutType.VAULT_DEPOSIT` will deposit the payout into the vault, and the user will receive vault shares.

Because the short pool is not allowed to store the WETH vault, and payouts are typically in WETH/ETH, it needs another way to get the appropriate vault to deposit to. It seems natural for the AddressProvider to fulfill this need, so a `vaults` mapping with getter/setter have been added to that contract. It will need to be redeployed.

This PR brings the deployed contract size for the BlastLongPool to 23.998 KiB, just barely under the size limit (unless Blast has a higher limit than mainnet). So merging this with the other open PRs may pose a challenge. We will need to investigate other optimizations.