### PR TITLE
Call `_vault.asset()` only once and store it for checks in `BaseWasabiPool.addVault`

### DIFF
--- a/contracts/BaseWasabiPool.sol
+++ b/contracts/BaseWasabiPool.sol
@@ -113,10 +113,11 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
     function addVault(IWasabiVault _vault) external onlyAdmin {
         if (_vault.getPoolAddress() != address(this)) revert InvalidVault();
         // Only long pool can have ETH vault
-        if (_vault.asset() == _getWethAddress() && !isLongPool) revert InvalidVault();
-        if (vaults[_vault.asset()] != address(0)) revert VaultAlreadyExists();
-        vaults[_vault.asset()] = address(_vault);
-        emit NewVault(address(this), _vault.asset(), address(_vault));
+        address asset = _vault.asset();
+        if (asset == _getWethAddress() && !isLongPool) revert InvalidVault();
+        if (vaults[asset] != address(0)) revert VaultAlreadyExists();
+        vaults[asset] = address(_vault);
+        emit NewVault(address(this), asset, address(_vault));
     }
 
     /// @dev Records the repayment of a position


### PR DESCRIPTION
In `BaseWasabiPool.addVault`, we had been calling `_vault.asset()` four times to:
 
1. check if the asset is WETH,
2. check if a vault already exists for the asset,
3. store the vault in the mapping w/ asset address as key, and
4. emit the `NewVault` event.
  
If the vault were malicious, then it could hypothetically return a different asset address on the third call, bypassing the check that prevents overwriting existing vaults. This is highly unlikely to happen - the `addVault` function can only be called by an admin, so exploiting this would require an admin PK leak.

Still, we should be calling `_vault.asset()` only once and storing it in a local variable. The more immediate and concrete benefit of fixing this is that it reduces the code size of all pool contracts by 0.313 KiB, which is important since they are close to the deployment size limit already. It should also save on gas, since it's doing three fewer external calls.