### PR TITLE
Always wrap ETH in `receivePayment`

### DIFF
--- a/contracts/PerpUtils.sol
+++ b/contracts/PerpUtils.sol
@@ -51,6 +51,7 @@ library PerpUtils {
         if (msg.value > 0) {
             if (_currency != _wethAddress) revert IWasabiPerps.InvalidCurrency();
             if (msg.value != _amount) revert IWasabiPerps.InsufficientAmountProvided();
+            wrapWETH(_wethAddress);
         } else {
             IERC20(_currency).safeTransferFrom(_sender, address(this), _amount);
         }


### PR DESCRIPTION
[WASAB-730](https://dkoda.atlassian.net/browse/WASAB-730?atlOrigin=eyJpIjoiZjJjNGFlMGNkZWRkNDgyZGFjNDM1M2JiOTE3MDFkN2YiLCJwIjoiaiJ9)

The long pool should only hold WETH going forward, so when traders send native ETH to open a position, wrap it. This will wrap all ETH held in the contract, which is important for the upcoming TVL migration, since `BaseWasabiPool.withdraw` does not wrap or transfer ETH when called from the vault.