### PR TITLE
Replace `claimAllGas` with `claimMaxGas`

### DIFF
--- a/contracts/blast/BlastLongPool.sol
+++ b/contracts/blast/BlastLongPool.sol
@@ -19,7 +19,7 @@ contract BlastLongPool is WasabiLongPool, AbstractBlastContract {
     function claimCollateralYield() external onlyAdmin {
         // Claim gas
         IBlast blast = _getBlast();
-        blast.claimAllGas(address(this), addressProvider.getFeeReceiver());
+        blast.claimMaxGas(address(this), addressProvider.getFeeReceiver());
 
         // Claim WETH yield
         IERC20Rebasing weth = IERC20Rebasing(BlastConstants.WETH);

--- a/contracts/blast/BlastShortPool.sol
+++ b/contracts/blast/BlastShortPool.sol
@@ -18,7 +18,7 @@ contract BlastShortPool is WasabiShortPool, AbstractBlastContract {
     function claimCollateralYield() external onlyAdmin {
         // Claim gas and yield
         IBlast blast = _getBlast();
-        blast.claimAllGas(address(this), addressProvider.getFeeReceiver());
+        blast.claimMaxGas(address(this), addressProvider.getFeeReceiver());
         blast.claimAllYield(address(this), addressProvider.getFeeReceiver());
 
         // Claim WETH yield

--- a/contracts/router/BlastRouter.sol
+++ b/contracts/router/BlastRouter.sol
@@ -27,7 +27,7 @@ contract BlastRouter is WasabiRouter, AbstractBlastContract {
     }
 
     /// @dev claim all gas
-    function claimAllGas(address contractAddress, address recipientOfGas) external onlyAdmin returns (uint256) {
-        return _getBlast().claimAllGas(contractAddress, recipientOfGas);
+    function claimGas(address contractAddress, address recipientOfGas) external onlyAdmin returns (uint256) {
+        return _getBlast().claimMaxGas(contractAddress, recipientOfGas);
     }
 }

--- a/contracts/vaults/BlastVault.sol
+++ b/contracts/vaults/BlastVault.sol
@@ -35,8 +35,8 @@ contract BlastVault is WasabiVault, AbstractBlastContract {
     }
 
     /// @dev claim all gas
-    function claimAllGas(address contractAddress, address recipientOfGas) external onlyOwner returns (uint256) {
-        return _getBlast().claimAllGas(contractAddress, recipientOfGas);
+    function claimGas(address contractAddress, address recipientOfGas) external onlyOwner returns (uint256) {
+        return _getBlast().claimMaxGas(contractAddress, recipientOfGas);
     }
 
     /// @dev claims yield


### PR DESCRIPTION
Addresses the following audit finding:
- https://github.com/sherlock-audit/2024-11-wasabi/issues/58

> Blast has a special gas mechanic where contract can claim some percentage of the gas they use. They can do that instantly for 50% of the funds, or wait up to a month in order to linearly unlock 100% of the used gas. In short, if a user uses 1 ETH worth of gas at time T, then at:
> 
> 1. At T the contract can claim 50%, or 0.5 ETH
> 2. At T + 2 weeks the contract can 75% or 0.75 ETH
> 3. At T + 1 month the contract can claim 100% or 1 ETH
> 
> All contracts claim their gas using claimAllGas, however this function claims 100% of the gas, while paying the fees for the one that is not fully unlocked, i.e. claiming all the gas, even if it' not fully unlocked. This means that every time the admin calls claimAllGas the system loses some percentage of all gas that was used inside the contracts for up to 1 month prior.
> 
> Example:
> 
> 1. User uses 1 ETH worth of gas at T
> 2. User uses 1 ETH worth of gas at T + 1 month
> 3. Admin calls claimAllGas
> 
> Now the system will claim the first 1 ETH, but only claim 50% of the second one and send the other 50% to Blast as fees for early claim, resulting in 1.5 ETH instead of 2.

Solution: Use `claimMaxGas` instead of `claimAllGas`. This function will claim all of the gas that is vested at 100% and leave the rest to continue vesting, which will result in claim rate of 100% every time.