### PR TITLE
Enforce `collateralSpent == _position.collateralAmount` in `WasabiLongPool::_closePositionInternal`

### DIFF
--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -251,7 +251,7 @@ contract WasabiLongPool is BaseWasabiPool {
         closeAmounts.payout = token.balanceOf(address(this)) - principalBalanceBefore;
 
         collateralSpent = collateralSpent - collateralToken.balanceOf(address(this));
-        if (collateralSpent > _position.collateralAmount) revert TooMuchCollateralSpent();
+        if (collateralSpent != _position.collateralAmount) revert TooMuchCollateralSpent();
 
         // 1. Deduct principal
         (closeAmounts.payout, closeAmounts.principalRepaid) = PerpUtils.deduct(closeAmounts.payout, _position.principal);


### PR DESCRIPTION
Addresses the following audit finding:
- https://github.com/sherlock-audit/2024-11-wasabi/issues/63

Even though we always use exact in swaps when closing long positions, such that `collateralSpent` should always equal `_position.collateralAmount`, it makes more sense to enforce this equality, rather than allowing `collateralSpent <= _position.collateralAmount`