### PR TITLE
Update `liquidationThreshold` calculation in short pool

### DIFF
--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -172,7 +172,7 @@ contract WasabiShortPool is BaseWasabiPool {
     ) external payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
         CloseAmounts memory closeAmounts =
             _closePositionInternal(_payoutType, _interest, _position, _swapFunctions, 0, true);
-        uint256 liquidationThreshold = _position.collateralAmount * 5 / 100;
+        uint256 liquidationThreshold = (_position.collateralAmount - _position.downPayment) * 5 / 100;
         if (closeAmounts.payout + closeAmounts.liquidationFee > liquidationThreshold) revert LiquidationThresholdNotReached();
 
         emit PositionLiquidated(

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -597,7 +597,7 @@ export async function deployShortPoolMockEnvironment() {
         const threshold = 500n; // 5 percent
 
         const currentInterest = await computeMaxInterest(position);
-        const payoutLiquidationThreshold = position.collateralAmount * (threshold + tradeFeeValue) / (feeDenominator - tradeFeeValue);
+        const payoutLiquidationThreshold = (position.collateralAmount - position.downPayment) * (threshold + tradeFeeValue) / (feeDenominator - tradeFeeValue);
 
         const liquidationAmount = position.collateralAmount - payoutLiquidationThreshold;
         return liquidationAmount * priceDenominator / (position.principal + currentInterest);


### PR DESCRIPTION
Addresses the following audit finding:
- https://github.com/sherlock-audit/2024-11-wasabi/issues/57

Changes this:
`uint256 liquidationThreshold = _position.collateralAmount * 5 / 100;`
to this:
`uint256 liquidationThreshold = (_position.collateralAmount - _position.downPayment) * 5 / 100;`