### PR TITLE
Clean vault function

### DIFF
--- a/contracts/vaults/IWasabiVault.sol
+++ b/contracts/vaults/IWasabiVault.sol
@@ -14,6 +14,7 @@ interface IWasabiVault is IERC4626  {
     error CallerNotPool();
     error InvalidEthAmount();
     error InvalidAmount();
+    error NoDustToClean();
 
     event NativeYieldClaimed(
         address token,

--- a/contracts/vaults/IWasabiVault.sol
+++ b/contracts/vaults/IWasabiVault.sol
@@ -41,6 +41,9 @@ interface IWasabiVault is IERC4626  {
     /// @param _amount The amount of assets to donate
     function donate(uint256 _amount) external;
 
+    /// @dev Called by the admin to remove any leftover assets if `totalSupply` is 0 and `totalAssetValue` is > 0
+    function cleanDust() external;
+
     /// @dev Validates that the leverage is within the maximum allowed by the DebtController
     /// @param _downPayment The down payment amount
     /// @param _total The total value of the position in the same currency as the down payment

--- a/contracts/vaults/WasabiVault.sol
+++ b/contracts/vaults/WasabiVault.sol
@@ -160,11 +160,13 @@ contract WasabiVault is IWasabiVault, UUPSUpgradeable, OwnableUpgradeable, ERC46
     }
 
     /// @inheritdoc IWasabiVault
-    function cleanDust() external onlyOwner {
+    function cleanDust() external onlyRole(Roles.VAULT_ADMIN_ROLE) {
         if (totalSupply() == 0 && totalAssetValue > 0) {
             uint256 assets = totalAssetValue;
             totalAssetValue = 0;
             IERC20(asset()).safeTransfer(msg.sender, assets);
+        } else {
+            revert NoDustToClean();
         }
     }
 

--- a/test/WasabiVault.test.ts
+++ b/test/WasabiVault.test.ts
@@ -70,6 +70,7 @@ describe("WasabiVault", function () {
             const {
                 user1,
                 owner,
+                vaultAdmin,
                 vault,
                 publicClient,
                 weth,
@@ -94,15 +95,16 @@ describe("WasabiVault", function () {
 
             // Donate dust
             const dust = 1n;
-            await weth.write.approve([vault.address, dust], { account: owner.account });
-            await vault.write.donate([dust], { account: owner.account });
+            await weth.write.deposit({ value: dust, account: vaultAdmin.account });
+            await weth.write.approve([vault.address, dust], { account: vaultAdmin.account });
+            await vault.write.donate([dust], { account: vaultAdmin.account });
 
             // Check distorting effect of dust
             const sharesPerEthBefore = await vault.read.convertToShares([parseEther("1")]);
             expect(sharesPerEthBefore).to.equal(parseEther("0.5"));
 
             // Clean dust
-            await vault.write.cleanDust({ account: owner.account });
+            await vault.write.cleanDust({ account: vaultAdmin.account });
 
             // Checks
             const sharesPerEthAfter = await vault.read.convertToShares([parseEther("1")]);
@@ -209,7 +211,7 @@ describe("WasabiVault", function () {
 
             await expect(vault.write.cleanDust(
                 { account: user1.account }
-            )).to.be.rejectedWith("OwnableUnauthorizedAccount");
+            )).to.be.rejectedWith("AccessManagerUnauthorizedAccount");
         })
         
         it("Only depositor can redeem", async function () {


### PR DESCRIPTION
Sometimes when the last LP in a vault withdraws their funds, if leaves the vault holding some dust, i.e., 1 wei of the asset. When `totalSupply() == 0` and `totalAssetValue > 0`, it distorts the number of shares per asset that new depositors will receive. This can be resolved by resetting the `totalAssetValue` to 0.

A new `cleanDust` function, callable by the contract owner, will send any leftover dust to the owner and reset `totalAssetValue` to 0. Additionally, to prevent this from occurring in the future, we check whether `totalSupply() == 0` in the internal withdraw function after burning the shares and decreasing the `totalAssetValue`. If so, we transfer the remaining dust to the sender with their withdrawn assets.