### PR TITLE
Reduce Blast pool code size 

### DIFF
--- a/contracts/blast/AbstractBlastContract.sol
+++ b/contracts/blast/AbstractBlastContract.sol
@@ -15,11 +15,7 @@ abstract contract AbstractBlastContract {
 
         IERC20Rebasing(BlastConstants.USDB).configure(YieldMode.CLAIMABLE);
         IERC20Rebasing(BlastConstants.WETH).configure(YieldMode.CLAIMABLE);
-    }
-
-    /// @dev configure the points operator
-    function _configurePointsOperator(address _operator) internal {
-        IBlastPoints(BlastConstants.BLAST_POINTS).configurePointsOperator(_operator);
+        IBlastPoints(BlastConstants.BLAST_POINTS).configurePointsOperator(msg.sender);
     }
 
     /// @dev returns the address of the Blast contract

--- a/contracts/blast/BlastLongPool.sol
+++ b/contracts/blast/BlastLongPool.sol
@@ -12,27 +12,25 @@ contract BlastLongPool is WasabiLongPool, AbstractBlastContract {
     function initialize(IAddressProvider _addressProvider, PerpManager _manager) public override initializer {
         __AbstractBlastContract_init();
         __BaseWasabiPool_init(true, _addressProvider, _manager); 
-        _configurePointsOperator(msg.sender);
     }
 
     /// @dev Claims the collateral yield + gas
     function claimCollateralYield() external onlyAdmin {
         // Claim gas
-        IBlast blast = _getBlast();
-        blast.claimMaxGas(address(this), addressProvider.getFeeReceiver());
+        _getBlast().claimMaxGas(address(this), addressProvider.getFeeReceiver());
 
         // Claim WETH yield
         IERC20Rebasing weth = IERC20Rebasing(BlastConstants.WETH);
-        uint256 claimableWETH = weth.getClaimableAmount(address(this));
-        if (claimableWETH > 0) {
-            weth.claim(addressProvider.getFeeReceiver(), claimableWETH);
+        uint256 claimable = weth.getClaimableAmount(address(this));
+        if (claimable > 0) {
+            weth.claim(addressProvider.getFeeReceiver(), claimable);
         }
 
         // Claim USDB yield
         IERC20Rebasing usdb = IERC20Rebasing(BlastConstants.USDB);
-        uint256 claimableUsdb = usdb.getClaimableAmount(address(this));
-        if (claimableUsdb > 0) {
-            usdb.claim(addressProvider.getFeeReceiver(), claimableUsdb);
+        claimable = usdb.getClaimableAmount(address(this));
+        if (claimable > 0) {
+            usdb.claim(addressProvider.getFeeReceiver(), claimable);
         }
     }
 }

--- a/contracts/blast/BlastPerpManager.sol
+++ b/contracts/blast/BlastPerpManager.sol
@@ -10,6 +10,5 @@ contract BlastPerpManager is PerpManager, AbstractBlastContract {
     function initialize() public override initializer {
         __AccessManager_init(msg.sender);
         __AbstractBlastContract_init();
-        _configurePointsOperator(msg.sender);
     }
 }

--- a/contracts/blast/BlastShortPool.sol
+++ b/contracts/blast/BlastShortPool.sol
@@ -11,7 +11,6 @@ contract BlastShortPool is WasabiShortPool, AbstractBlastContract {
     function initialize(IAddressProvider _addressProvider, PerpManager _manager) public override initializer {
         __AbstractBlastContract_init();
         __BaseWasabiPool_init(false, _addressProvider, _manager);
-        _configurePointsOperator(msg.sender);
     }
 
     /// @dev Claims the collateral yield + gas
@@ -23,16 +22,16 @@ contract BlastShortPool is WasabiShortPool, AbstractBlastContract {
 
         // Claim WETH yield
         IERC20Rebasing weth = IERC20Rebasing(BlastConstants.WETH);
-        uint256 claimableWETH = weth.getClaimableAmount(address(this));
-        if (claimableWETH > 0) {
-            weth.claim(addressProvider.getFeeReceiver(), claimableWETH);
+        uint256 claimable = weth.getClaimableAmount(address(this));
+        if (claimable > 0) {
+            weth.claim(addressProvider.getFeeReceiver(), claimable);
         }
 
         // Claim USDB yield
         IERC20Rebasing usdb = IERC20Rebasing(BlastConstants.USDB);
-        uint256 claimableUsdb = usdb.getClaimableAmount(address(this));
-        if (claimableUsdb > 0) {
-            usdb.claim(addressProvider.getFeeReceiver(), claimableUsdb);
+        claimable = usdb.getClaimableAmount(address(this));
+        if (claimable > 0) {
+            usdb.claim(addressProvider.getFeeReceiver(), claimable);
         }
     }
 }

--- a/contracts/router/BlastRouter.sol
+++ b/contracts/router/BlastRouter.sol
@@ -24,7 +24,6 @@ contract BlastRouter is WasabiRouter, AbstractBlastContract {
     ) public override initializer {
         __WasabiRouter_init(_longPool, _shortPool, _weth, _manager, _swapRouter, _feeReceiver, _withdrawFeeBips);
         __AbstractBlastContract_init();
-        _configurePointsOperator(msg.sender);
     }
 
     /// @dev claim all gas

--- a/contracts/vaults/BlastVault.sol
+++ b/contracts/vaults/BlastVault.sol
@@ -32,7 +32,6 @@ contract BlastVault is WasabiVault, AbstractBlastContract {
         __ERC20_init(name, symbol);
         __ReentrancyGuard_init();
         __UUPSUpgradeable_init();
-        _configurePointsOperator(msg.sender);
         addressProvider = _addressProvider;
         longPool = _longPool;
         shortPool = _shortPool;


### PR DESCRIPTION
With the code being added for editing positions, we are pushing the size of the Blast pools over the limit of 24 KB. We may just need to remove `claimPosition` in the end, but first we should try to optimize elsewhere.

We might even be able to remove most or all of the initializer logic from the Blast pools, since they have already been initialized and we won't need to deploy any more (though we may still deploy new vaults on Blast which would need initialization).