### PR TITLE
Add support for deposit cap to WasabiVault

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "node_modules"
           key: node_modules-${{ hashFiles('package-lock.json') }}

--- a/contracts/vaults/IWasabiVault.sol
+++ b/contracts/vaults/IWasabiVault.sol
@@ -15,7 +15,6 @@ interface IWasabiVault is IERC4626  {
     error InvalidEthAmount();
     error InvalidAmount();
     error NoDustToClean();
-    error NewDepositCapBelowTotalAssets();
 
     event NativeYieldClaimed(
         address token,

--- a/contracts/vaults/IWasabiVault.sol
+++ b/contracts/vaults/IWasabiVault.sol
@@ -15,10 +15,15 @@ interface IWasabiVault is IERC4626  {
     error InvalidEthAmount();
     error InvalidAmount();
     error NoDustToClean();
+    error NewDepositCapBelowTotalAssets();
 
     event NativeYieldClaimed(
         address token,
         uint256 amount
+    );
+
+    event DepositCapUpdated(
+        uint256 newDepositCap
     );
 
     /// @dev Deposits ETH into the vault (only WETH vault)
@@ -50,4 +55,8 @@ interface IWasabiVault is IERC4626  {
     /// @param _total The total value of the position in the same currency as the down payment
     /// @notice For shorts, _total is the collateral amount, for longs it is the down payment + principal
     function checkMaxLeverage(uint256 _downPayment, uint256 _total) external view;
+
+    /// @dev Sets the cap on the amount of assets that can be deposited by all users
+    /// @param _newDepositCap The new deposit cap
+    function setDepositCap(uint256 _newDepositCap) external;
 }

--- a/contracts/vaults/WasabiVault.sol
+++ b/contracts/vaults/WasabiVault.sol
@@ -30,7 +30,7 @@ contract WasabiVault is IWasabiVault, UUPSUpgradeable, OwnableUpgradeable, ERC46
 
     // @notice The slot where the deposit cap is stored, if set
     // @dev This equals bytes32(uint256(keccak256("wasabi.vault.max_deposit")) - 1)
-    bytes32 public constant DEPOSIT_CAP_SLOT = 0x5f64ef5afc66734d661a0e9d6aa10a8d47dcf2c1c681696cce952f8ef9115384;
+    bytes32 private constant DEPOSIT_CAP_SLOT = 0x5f64ef5afc66734d661a0e9d6aa10a8d47dcf2c1c681696cce952f8ef9115384;
 
     modifier onlyPool() {
         if (msg.sender != address(shortPool)) {

--- a/contracts/vaults/WasabiVault.sol
+++ b/contracts/vaults/WasabiVault.sol
@@ -29,8 +29,8 @@ contract WasabiVault is IWasabiVault, UUPSUpgradeable, OwnableUpgradeable, ERC46
     uint256 private constant LEVERAGE_DENOMINATOR = 100;
 
     // @notice The slot where the deposit cap is stored, if set
-    // @dev This equals bytes32(uint256(keccak256("DEPOSIT_CAP")) - 1)
-    bytes32 private constant DEPOSIT_CAP_SLOT = 0xc6d52ffaf3a6c9c0e7544395ce44230c509224ed3ddbc82e13e01f760c4f7792;
+    // @dev This equals bytes32(uint256(keccak256("wasabi.vault.max_deposit")) - 1)
+    bytes32 public constant DEPOSIT_CAP_SLOT = 0x5f64ef5afc66734d661a0e9d6aa10a8d47dcf2c1c681696cce952f8ef9115384;
 
     modifier onlyPool() {
         if (msg.sender != address(shortPool)) {

--- a/contracts/vaults/WasabiVault.sol
+++ b/contracts/vaults/WasabiVault.sol
@@ -99,7 +99,11 @@ contract WasabiVault is IWasabiVault, UUPSUpgradeable, OwnableUpgradeable, ERC46
 
     /// @inheritdoc ERC4626Upgradeable
     function maxDeposit(address) public view override(ERC4626Upgradeable, IERC4626) returns (uint256) {
-        return _getDepositCap() - totalAssetValue;
+        uint256 depositCap = _getDepositCap();
+        if (totalAssetValue >= depositCap) {
+            return 0;
+        }
+        return depositCap - totalAssetValue;
     }
 
     /// @inheritdoc IWasabiVault
@@ -182,9 +186,6 @@ contract WasabiVault is IWasabiVault, UUPSUpgradeable, OwnableUpgradeable, ERC46
 
     /// @inheritdoc IWasabiVault
     function setDepositCap(uint256 _newDepositCap) external onlyAdmin {
-        if (_newDepositCap < totalAssetValue && _newDepositCap != 0) {
-            revert NewDepositCapBelowTotalAssets();
-        }
         StorageSlot.getUint256Slot(DEPOSIT_CAP_SLOT).value = _newDepositCap;
         emit DepositCapUpdated(_newDepositCap);
     }

--- a/contracts/vaults/WasabiVault.sol
+++ b/contracts/vaults/WasabiVault.sol
@@ -100,6 +100,9 @@ contract WasabiVault is IWasabiVault, UUPSUpgradeable, OwnableUpgradeable, ERC46
     /// @inheritdoc ERC4626Upgradeable
     function maxDeposit(address) public view override(ERC4626Upgradeable, IERC4626) returns (uint256) {
         uint256 depositCap = _getDepositCap();
+        if (depositCap == type(uint256).max) {
+            return type(uint256).max;
+        }
         if (totalAssetValue >= depositCap) {
             return 0;
         }

--- a/test/WasabiVault.test.ts
+++ b/test/WasabiVault.test.ts
@@ -256,7 +256,7 @@ describe("WasabiVault", function () {
             const shares = await vault.read.balanceOf([owner.account.address]);
             const assets = await vault.read.convertToAssets([shares]);
 
-            expect(await vault.read.maxDeposit([user1.account.address])).to.equal(maxUint256 - assets);
+            expect(await vault.read.maxDeposit([user1.account.address])).to.equal(maxUint256);
 
             // Set the deposit cap to 2x the current assets
             await vault.write.setDepositCap([assets * 2n], { account: owner.account });

--- a/test/WasabiVault.test.ts
+++ b/test/WasabiVault.test.ts
@@ -276,26 +276,5 @@ describe("WasabiVault", function () {
                 { account: user1.account }
             )).to.be.rejectedWith("ERC4626ExceededMaxDeposit");
         });
-
-        it("Cannot set deposit cap to less than total assets", async function () {
-            const {vault, owner} = await loadFixture(deployLongPoolMockEnvironment);
-
-            // Owner already deposited in fixture
-            const shares = await vault.read.balanceOf([owner.account.address]);
-            const assets = await vault.read.convertToAssets([shares]);
-
-            await expect(vault.write.setDepositCap(
-                [assets - 1n], 
-                { account: owner.account }
-            )).to.be.rejectedWith("NewDepositCapBelowTotalAssets");
-
-            // Passing in zero should effectively set the cap to type(uint256).max
-            await expect(vault.write.setDepositCap(
-                [0n], 
-                { account: owner.account }
-            )).to.be.fulfilled;
-
-            expect(await vault.read.maxDeposit([owner.account.address])).to.equal(maxUint256 - assets);
-        });
     });
 });


### PR DESCRIPTION
Accomplished by overriding the `maxDeposit` function from ERC4626, returning `_getDepositCap() - totalAssetValue` instead of `type(uint256).max`.

Uses unstructured storage to store the cap value, so it doesn't affect the storage layout of the BeraVault. The slot equals `bytes32(uint256(keccak256("DEPOSIT_CAP")) - 1)`.

If there is no value set in this slot, then `_getDepositCap()` returns `type(uint256).max`.