### PR TITLE
Reward fee shares update on transfers

### DIFF
--- a/contracts/mock/MockBeraVault.sol
+++ b/contracts/mock/MockBeraVault.sol
@@ -30,4 +30,8 @@ contract MockBeraVault is BeraVault {
 
         _approve(address(this), address(rs.infraredVault), type(uint256).max);
     }
+
+    function getRewardFeeUserBalance(address account) external view returns (uint256) {
+        return _getRewardStorage().rewardFeeUserBalance[account];
+    }
 }

--- a/contracts/vaults/BeraVault.sol
+++ b/contracts/vaults/BeraVault.sol
@@ -11,9 +11,6 @@ contract BeraVault is WasabiVault, IBeraVault {
     using SafeERC20 for IERC20;
     using Math for uint256;
 
-    /// @custom:oz-renamed-from rewardVault
-    IRewardVault public _rewardVaultDeprecated;
-
     struct RewardStorage {
         IRewardVault rewardVault;
         uint256 rewardFeeBips;
@@ -110,18 +107,6 @@ contract BeraVault is WasabiVault, IBeraVault {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                       ADMIN FUNCTIONS                      */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-
-    /// @inheritdoc IBeraVault
-    function migrateFees(IInfraredVault infraredVault) external onlyAdmin {
-        RewardStorage storage rs = _getRewardStorage();
-        rs.infraredVault = infraredVault;
-        _approve(address(this), address(infraredVault), type(uint256).max);
-
-        IRewardVault rewardVault = rs.rewardVault;
-        uint256 totalFeeStake = rewardVault.balanceOf(address(this));
-        rewardVault.withdraw(totalFeeStake);
-        infraredVault.stake(totalFeeStake);
-    }
 
     /// @inheritdoc IBeraVault
     function claimRewardFees(address _receiver) external onlyAdmin returns (uint256[] memory) {

--- a/contracts/vaults/BeraVault.sol
+++ b/contracts/vaults/BeraVault.sol
@@ -75,7 +75,7 @@ contract BeraVault is WasabiVault, IBeraVault {
         uint256 balance = balanceOf(owner);
         if (balance == 0) return 0;
 
-        uint256 partialFees = _computePartialFee(owner, shares);(owner, balance);
+        uint256 partialFees = _computePartialFee(owner, balance);
         return partialFees + balance;
     }
 

--- a/contracts/vaults/IBeraVault.sol
+++ b/contracts/vaults/IBeraVault.sol
@@ -34,8 +34,4 @@ interface IBeraVault is IWasabiVault {
     /// @param _receiver The address to receive the rewards
     /// @return The amount of each reward token claimed
     function claimRewardFees(address _receiver) external returns (uint256[] memory);
-
-    /// @notice Migrate fee portion from pre-existing deposits to the new InfraredVault
-    /// @param infraredVault The InfraredVault contract to migrate fees to
-    function migrateFees(IInfraredVault infraredVault) external;
 }


### PR DESCRIPTION
Since we re-enabled transfers on our Bera vaults, we need to update our internal accounting of reward fee balances to account for share transfers between user accounts. To do so we need to override `transfer` and `transferFrom`.

The` transfer` scenarios are: 
1. If the sender is either the RewardVault or the InfraredVault, it's an unstaking tx and we just do the transfer w/o editing the reward fees
2. Otherwise, if the recipient is the RewardVault, InfraredVault or our BeraVault we revert, since staking is done using transferFrom and direct transfers can lead to loss of funds
3. Otherwise, we move a portion of the reward fee shares from the sender to the recipient

And the `transferFrom` scenarios are:
1. If the recipient is either the RewardVault or the InfraredVault, it's a staking tx and we just do the transfer
2. Otherwise, we move a portion of the reward fee shares from the sender to the recipient