### PR TITLE
Levered longs with collateral staking

### DIFF
--- a/contracts/IWasabiPerps.sol
+++ b/contracts/IWasabiPerps.sol
@@ -212,7 +212,7 @@ interface IWasabiPerps {
     function openPosition(
         OpenPositionRequest calldata _request,
         Signature calldata _signature
-    ) external payable;
+    ) external payable returns (Position memory);
 
     /// @dev Opens a position on behalf of a user
     /// @param _request the request to open a position
@@ -222,7 +222,7 @@ interface IWasabiPerps {
         OpenPositionRequest calldata _request,
         Signature calldata _signature,
         address _trader
-    ) external payable;
+    ) external payable returns (Position memory);
 
     /// @dev Closes a position
     /// @param _payoutType whether to send WETH to the trader, send ETH, or deposit WETH to the vault

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -23,8 +23,8 @@ contract WasabiLongPool is BaseWasabiPool {
     function openPosition(
         OpenPositionRequest calldata _request,
         Signature calldata _signature
-    ) external payable {
-        openPositionFor(_request, _signature, msg.sender);
+    ) external payable returns (Position memory) {
+        return openPositionFor(_request, _signature, msg.sender);
     }
 
     /// @inheritdoc IWasabiPerps
@@ -32,7 +32,7 @@ contract WasabiLongPool is BaseWasabiPool {
         OpenPositionRequest calldata _request,
         Signature calldata _signature,
         address _trader
-    ) public payable nonReentrant {
+    ) public payable nonReentrant returns (Position memory) {
         // Validate Request
         _validateOpenPositionRequest(_request, _signature);
 
@@ -75,6 +75,8 @@ contract WasabiLongPool is BaseWasabiPool {
             position.collateralAmount,
             position.feesToBePaid
         );
+
+        return position;
     }
 
     /// @inheritdoc IWasabiPerps

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -173,7 +173,7 @@ contract WasabiLongPool is BaseWasabiPool {
     }
 
     /// @inheritdoc IWasabiPerps
-    function claimPosition(Position calldata _position) external payable nonReentrant {
+    function claimPosition(Position calldata _position) external virtual payable nonReentrant {
         if (positions[_position.id] != _position.hash()) revert InvalidPosition();
         if (_position.trader != msg.sender) revert SenderNotTrader();
 

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -174,6 +174,10 @@ contract WasabiLongPool is BaseWasabiPool {
 
     /// @inheritdoc IWasabiPerps
     function claimPosition(Position calldata _position) external virtual payable nonReentrant {
+        _claimPositionInternal(_position);
+    }
+
+    function _claimPositionInternal(Position calldata _position) internal virtual {
         if (positions[_position.id] != _position.hash()) revert InvalidPosition();
         if (_position.trader != msg.sender) revert SenderNotTrader();
 

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -16,6 +16,10 @@ contract WasabiLongPool is BaseWasabiPool {
     /// @param _addressProvider address provider contract
     /// @param _manager the PerpManager contract
     function initialize(IAddressProvider _addressProvider, PerpManager _manager) public virtual initializer {
+        __WasabiLongPool_init(_addressProvider, _manager);
+    }
+
+    function __WasabiLongPool_init(IAddressProvider _addressProvider, PerpManager _manager) internal virtual onlyInitializing {
         __BaseWasabiPool_init(true, _addressProvider, _manager);
     }
 

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -235,7 +235,7 @@ contract WasabiLongPool is BaseWasabiPool {
         FunctionCallData[] calldata _swapFunctions,
         uint256 _executionFee,
         bool _isLiquidation
-    ) internal returns(CloseAmounts memory closeAmounts) {
+    ) internal virtual returns (CloseAmounts memory closeAmounts) {
         if (positions[_position.id] != _position.hash()) revert InvalidPosition();
         if (_swapFunctions.length == 0) revert SwapFunctionNeeded();
 

--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -23,8 +23,8 @@ contract WasabiShortPool is BaseWasabiPool {
     function openPosition(
         OpenPositionRequest calldata _request,
         Signature calldata _signature
-    ) external payable {
-        openPositionFor(_request, _signature, msg.sender);
+    ) external payable returns (Position memory) {
+        return openPositionFor(_request, _signature, msg.sender);
     }
 
     /// @inheritdoc IWasabiPerps
@@ -32,7 +32,7 @@ contract WasabiShortPool is BaseWasabiPool {
         OpenPositionRequest calldata _request,
         Signature calldata _signature,
         address _trader
-    ) public payable nonReentrant {
+    ) public payable nonReentrant returns (Position memory) {
         // Validate Request
         _validateOpenPositionRequest(_request, _signature);
 
@@ -87,6 +87,8 @@ contract WasabiShortPool is BaseWasabiPool {
             position.collateralAmount,
             position.feesToBePaid
         );
+
+        return position;
     }
 
     /// @inheritdoc IWasabiPerps

--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -192,7 +192,7 @@ contract WasabiShortPool is BaseWasabiPool {
     }
 
     /// @inheritdoc IWasabiPerps
-    function claimPosition(Position calldata _position) external payable nonReentrant {
+    function claimPosition(Position calldata _position) external virtual payable nonReentrant {
         if (positions[_position.id] != _position.hash()) revert InvalidPosition();
         if (_position.trader != msg.sender) revert SenderNotTrader();
 

--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -16,6 +16,10 @@ contract WasabiShortPool is BaseWasabiPool {
     /// @param _addressProvider address provider contract
     /// @param _manager the PerpManager contract
     function initialize(IAddressProvider _addressProvider, PerpManager _manager) public virtual initializer {
+        __WasabiShortPool_init(_addressProvider, _manager);
+    }
+
+    function __WasabiShortPool_init(IAddressProvider _addressProvider, PerpManager _manager) internal virtual onlyInitializing {
         __BaseWasabiPool_init(false, _addressProvider, _manager);
     }
 

--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -249,7 +249,7 @@ contract WasabiShortPool is BaseWasabiPool {
         FunctionCallData[] calldata _swapFunctions,
         uint256 _executionFee,
         bool _isLiquidation
-    ) internal returns(CloseAmounts memory closeAmounts) {
+    ) internal virtual returns (CloseAmounts memory closeAmounts) {
         if (positions[_position.id] != _position.hash()) revert InvalidPosition();
         if (_swapFunctions.length == 0) revert SwapFunctionNeeded();
 

--- a/contracts/addressProvider/AddressProvider.sol
+++ b/contracts/addressProvider/AddressProvider.sol
@@ -17,19 +17,22 @@ contract AddressProvider is Ownable, IAddressProvider {
     address public feeReceiver;
     address public immutable wethAddress;
     address public liquidationFeeReceiver;
+    address public stakingAccountFactory;
 
     constructor(
         IDebtController _debtController,
         IWasabiRouter _wasabiRouter,
         address _feeReceiver,
         address _wethAddress,
-        address _liquidationFeeReceiver
+        address _liquidationFeeReceiver,
+        address _stakingAccountFactory
     ) Ownable(msg.sender) {
         debtController = _debtController;
         wasabiRouter = _wasabiRouter;
         feeReceiver = _feeReceiver;
         wethAddress = _wethAddress;
         liquidationFeeReceiver = _liquidationFeeReceiver;
+        stakingAccountFactory = _stakingAccountFactory;
     }
 
     /// @inheritdoc IAddressProvider
@@ -77,6 +80,11 @@ contract AddressProvider is Ownable, IAddressProvider {
         return wethAddress;
     }
 
+    /// @inheritdoc IAddressProvider
+    function getStakingAccountFactory() external view returns (address) {
+        return stakingAccountFactory;
+    }
+
     /// @dev sets the debt controller
     /// @param _debtController the debt controller
     function setDebtController(IDebtController _debtController) external onlyOwner {
@@ -101,5 +109,12 @@ contract AddressProvider is Ownable, IAddressProvider {
     function setLiquidationFeeReceiver(address _liquidationFeeReceiver) external onlyOwner {
         if (_liquidationFeeReceiver == address(0)) revert InvalidAddress();
         liquidationFeeReceiver = _liquidationFeeReceiver;
+    }
+
+    /// @dev sets the staking account factory
+    /// @param _stakingAccountFactory the staking account factory
+    function setStakingAccountFactory(address _stakingAccountFactory) external onlyOwner {
+        if (_stakingAccountFactory == address(0)) revert InvalidAddress();
+        stakingAccountFactory = _stakingAccountFactory;
     }
 }

--- a/contracts/addressProvider/IAddressProvider.sol
+++ b/contracts/addressProvider/IAddressProvider.sol
@@ -21,4 +21,7 @@ interface IAddressProvider {
 
      /// @dev Returns the fee receiver address
     function getLiquidationFeeReceiver() external view returns (address);
+
+    /// @dev Returns the staking account factory address
+    function getStakingAccountFactory() external view returns (address);
 }

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -105,7 +105,7 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
 
     /// @dev Stakes the collateral of a given position via the staking account factory
     /// @param _position the position to stake
-    function _stake(Position memory _position) internal {
+    function _stake(Position memory _position) internal nonReentrant {
         StakingStorage storage $ = _getStakingStorage();
         if ($.isStaked[_position.id]) revert PositionAlreadyStaked(_position.id);
         $.isStaked[_position.id] = true;

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -108,12 +108,12 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
     function _stake(Position memory _position) internal {
         StakingStorage storage $ = _getStakingStorage();
         if ($.isStaked[_position.id]) revert PositionAlreadyStaked(_position.id);
+        $.isStaked[_position.id] = true;
 
         IStakingAccountFactory factory = _getStakingAccountFactory();
         IERC20(_position.collateralCurrency).forceApprove(address(factory), _position.collateralAmount);
 
         factory.stakePosition(_position);
-        $.isStaked[_position.id] = true;
     }
 
     /// @dev Unstakes the collateral of a given position via the staking account factory if it is staked
@@ -121,8 +121,8 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
     function _unstakeIfStaked(Position memory _position) internal {
         StakingStorage storage $ = _getStakingStorage();
         if ($.isStaked[_position.id]) {
-            _getStakingAccountFactory().unstakePosition(_position);
             $.isStaked[_position.id] = false;
+            _getStakingAccountFactory().unstakePosition(_position);
         }
     }
 

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -13,8 +13,8 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
     }
 
     // @notice The slot where the StakingStorage struct is stored
-    // @dev This equals bytes32(uint256(keccak256("wasabi.bera.pool.staking_storage")) - 1)
-    bytes32 private constant STAKING_STORAGE_SLOT = 0x0d8f064b21e6d7bd141e4ffc80d57d52569485729c3fe408a96c6787eff132d2;
+    // @dev This equals bytes32(uint256(keccak256("wasabi.pool.staking_storage")) - 1)
+    bytes32 private constant STAKING_STORAGE_SLOT = 0xd7d4cbe20940e82007292c0d2939a485e1e8c3c257e382f7fa5a10e24698ab5d;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                        INITIALIZER                         */

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -28,6 +28,16 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           GETTERS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @inheritdoc IBeraPool
+    function isPositionStaked(uint256 _positionId) external view returns (bool) {
+        StakingStorage storage $ = _getStakingStorage();
+        return $.isStaked[_positionId];
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           WRITES                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
@@ -50,7 +60,8 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
         return position;
     }
 
-    function stakePosition(Position memory _position) external payable {
+    /// @inheritdoc IBeraPool
+    function stakePosition(Position memory _position) external {
         if (_position.trader != msg.sender) revert CallerNotTrader();
         _stake(_position);
     }
@@ -76,7 +87,14 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
         bool _isLiquidation
     ) internal override returns(CloseAmounts memory closeAmounts) {
         _unstakeIfStaked(_position);
-        return super._closePositionInternal(_payoutType, _interest, _position, _swapFunctions, _executionFee, _isLiquidation);
+        return super._closePositionInternal(
+            _payoutType, 
+            _interest, 
+            _position, 
+            _swapFunctions, 
+            _executionFee, 
+            _isLiquidation
+        );
     }
 
     /// @dev Stakes the collateral of a given position via the staking account factory

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -62,8 +62,14 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
 
     /// @inheritdoc IBeraPool
     function stakePosition(Position memory _position) external {
-        if (_position.trader != msg.sender) revert CallerNotTrader();
+        if (_position.trader != msg.sender) revert SenderNotTrader();
         _stake(_position);
+    }
+
+    /// @inheritdoc IWasabiPerps
+    function claimPosition(Position calldata _position) external payable nonReentrant {
+        _unstakeIfStaked(_position);
+        super.claimPosition(_position);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "../WasabiLongPool.sol";
+import "./IBeraPool.sol";
+import "./IStakingAccountFactory.sol";
+
+contract BeraLongPool is WasabiLongPool, IBeraPool {
+    using SafeERC20 for IERC20;
+    
+    struct StakingStorage {
+        mapping(uint256 => bool) isStaked;
+    }
+
+    // @notice The slot where the StakingStorage struct is stored
+    // @dev This equals bytes32(uint256(keccak256("wasabi.bera.pool.staking_storage")) - 1)
+    bytes32 private constant STAKING_STORAGE_SLOT = 0x0d8f064b21e6d7bd141e4ffc80d57d52569485729c3fe408a96c6787eff132d2;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        INITIALIZER                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev initializer for proxy
+    /// @param _addressProvider address provider contract
+    /// @param _manager the PerpManager contract
+    function initialize(IAddressProvider _addressProvider, PerpManager _manager) public override initializer {
+        __BaseWasabiPool_init(true, _addressProvider, _manager);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           WRITES                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function openPositionAndStake(
+        OpenPositionRequest calldata _request, 
+        Signature calldata _signature
+    ) external payable returns (Position memory) {
+        return openPositionAndStakeFor(_request, _signature, msg.sender);
+    }
+
+    function openPositionAndStakeFor(
+        OpenPositionRequest calldata _request,
+        Signature calldata _signature,
+        address _trader
+    ) public payable returns (Position memory) {
+        Position memory position = openPositionFor(_request, _signature, _trader);
+        _stake(position);
+        return position;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      INTERNAL FUNCTIONS                    */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Closes a given position
+    /// @param _payoutType whether to send WETH to the trader, send ETH, or deposit WETH to the vault
+    /// @param _interest the interest amount to be paid
+    /// @param _position the position
+    /// @param _swapFunctions the swap functions
+    /// @param _executionFee the execution fee
+    /// @param _isLiquidation flag indicating if the close is a liquidation
+    /// @return closeAmounts the close amounts
+    function _closePositionInternal(
+        PayoutType _payoutType,
+        uint256 _interest,
+        Position calldata _position,
+        FunctionCallData[] calldata _swapFunctions,
+        uint256 _executionFee,
+        bool _isLiquidation
+    ) internal override returns(CloseAmounts memory closeAmounts) {
+        _unstakeIfStaked(_position);
+        return super._closePositionInternal(_payoutType, _interest, _position, _swapFunctions, _executionFee, _isLiquidation);
+    }
+
+    function _stake(Position memory _position) internal {
+        IStakingAccountFactory factory = _getStakingAccountFactory();
+        IERC20(_position.collateralCurrency).forceApprove(address(factory), _position.collateralAmount);
+        factory.stakePosition(_position);
+        _getStakingStorage().isStaked[_position.id] = true;
+    }
+
+    function _unstakeIfStaked(Position memory _position) internal {
+        StakingStorage storage $ = _getStakingStorage();
+        if ($.isStaked[_position.id]) {
+            _getStakingAccountFactory().unstakePosition(_position);
+            $.isStaked[_position.id] = false;
+        }
+    }
+
+    function _getStakingAccountFactory() internal view returns (IStakingAccountFactory) {
+        return IStakingAccountFactory(addressProvider.getStakingAccountFactory());
+    }
+
+    function _getStakingStorage() internal pure returns (StakingStorage storage $) {
+        assembly {
+            $.slot := STAKING_STORAGE_SLOT
+        }
+    }
+}

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -31,6 +31,7 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
     /*                           WRITES                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
+    /// @inheritdoc IBeraPool
     function openPositionAndStake(
         OpenPositionRequest calldata _request, 
         Signature calldata _signature
@@ -38,6 +39,7 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
         return openPositionAndStakeFor(_request, _signature, msg.sender);
     }
 
+    /// @inheritdoc IBeraPool
     function openPositionAndStakeFor(
         OpenPositionRequest calldata _request,
         Signature calldata _signature,
@@ -72,6 +74,8 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
         return super._closePositionInternal(_payoutType, _interest, _position, _swapFunctions, _executionFee, _isLiquidation);
     }
 
+    /// @dev Stakes the collateral of a given position via the staking account factory
+    /// @param _position the position to stake
     function _stake(Position memory _position) internal {
         IStakingAccountFactory factory = _getStakingAccountFactory();
         IERC20(_position.collateralCurrency).forceApprove(address(factory), _position.collateralAmount);
@@ -79,6 +83,8 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
         _getStakingStorage().isStaked[_position.id] = true;
     }
 
+    /// @dev Unstakes the collateral of a given position via the staking account factory if it is staked
+    /// @param _position the position to unstake
     function _unstakeIfStaked(Position memory _position) internal {
         StakingStorage storage $ = _getStakingStorage();
         if ($.isStaked[_position.id]) {
@@ -87,10 +93,14 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
         }
     }
 
+    /// @dev Returns the staking account factory from the address provider
+    /// @return factory the staking account factory
     function _getStakingAccountFactory() internal view returns (IStakingAccountFactory) {
         return IStakingAccountFactory(addressProvider.getStakingAccountFactory());
     }
 
+    /// @dev Returns the staking storage struct
+    /// @return $ the staking storage
     function _getStakingStorage() internal pure returns (StakingStorage storage $) {
         assembly {
             $.slot := STAKING_STORAGE_SLOT

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -67,9 +67,9 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
     }
 
     /// @inheritdoc IWasabiPerps
-    function claimPosition(Position calldata _position) external payable nonReentrant {
+    function claimPosition(Position calldata _position) external override(IWasabiPerps, WasabiLongPool) payable nonReentrant {
         _unstakeIfStaked(_position);
-        super.claimPosition(_position);
+        _claimPositionInternal(_position);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/bera/BeraLongPool.sol
+++ b/contracts/bera/BeraLongPool.sol
@@ -24,7 +24,7 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
     /// @param _addressProvider address provider contract
     /// @param _manager the PerpManager contract
     function initialize(IAddressProvider _addressProvider, PerpManager _manager) public override initializer {
-        __BaseWasabiPool_init(true, _addressProvider, _manager);
+        __WasabiLongPool_init(_addressProvider, _manager);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -87,7 +87,7 @@ contract BeraLongPool is WasabiLongPool, IBeraPool {
 
         IStakingAccountFactory factory = _getStakingAccountFactory();
         IERC20(_position.collateralCurrency).forceApprove(address(factory), _position.collateralAmount);
-        
+
         factory.stakePosition(_position);
         $.isStaked[_position.id] = true;
     }

--- a/contracts/bera/IBeraPool.sol
+++ b/contracts/bera/IBeraPool.sol
@@ -5,7 +5,6 @@ import "../IWasabiPerps.sol";
 
 interface IBeraPool is IWasabiPerps {
     error PositionAlreadyStaked(uint256 _positionId);
-    error CallerNotTrader();
 
     /// @notice Opens a position and stakes the collateral
     /// @param _request the request to open a position

--- a/contracts/bera/IBeraPool.sol
+++ b/contracts/bera/IBeraPool.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "../IWasabiPerps.sol";
+
+interface IBeraPool is IWasabiPerps {
+    /// @notice Opens a position and stakes the collateral
+    /// @param _request the request to open a position
+    /// @param _signature the signature of the request
+    function openPositionAndStake(
+        OpenPositionRequest calldata _request, 
+        Signature calldata _signature
+    ) external payable returns (Position memory);
+
+    /// @dev Opens a position on behalf of a user and stakes the collateral
+    /// @param _request the request to open a position
+    /// @param _signature the signature of the request
+    /// @param _trader the address of the user for whom the position is opened
+    function openPositionAndStakeFor(
+        OpenPositionRequest calldata _request,
+        Signature calldata _signature,
+        address _trader
+    ) external payable returns (Position memory);
+}

--- a/contracts/bera/IBeraPool.sol
+++ b/contracts/bera/IBeraPool.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.23;
 import "../IWasabiPerps.sol";
 
 interface IBeraPool is IWasabiPerps {
+    error PositionAlreadyStaked(uint256 _positionId);
+    error CallerNotTrader();
+
     /// @notice Opens a position and stakes the collateral
     /// @param _request the request to open a position
     /// @param _signature the signature of the request

--- a/contracts/bera/IBeraPool.sol
+++ b/contracts/bera/IBeraPool.sol
@@ -24,4 +24,13 @@ interface IBeraPool is IWasabiPerps {
         Signature calldata _signature,
         address _trader
     ) external payable returns (Position memory);
+
+    /// @notice Stakes a position
+    /// @param _position the position to stake
+    function stakePosition(Position memory _position) external;
+
+    /// @notice Returns true if the position is staked
+    /// @param _positionId the id of the position
+    /// @return true if the position is staked, false otherwise
+    function isPositionStaked(uint256 _positionId) external view returns (bool);
 }

--- a/contracts/bera/IStakingAccount.sol
+++ b/contracts/bera/IStakingAccount.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../IWasabiPerps.sol";
+import "./IInfraredVault.sol";
+
+interface IStakingAccount {
+    error TraderNotAccountHolder();
+    error CallerNotFactory();
+
+    /// @notice Stakes the collateral of a position in the Infrared vault
+    /// @param _position The position to stake
+    function stakePosition(IWasabiPerps.Position memory _position, IInfraredVault _vault) external;
+
+    /// @notice Unstakes the collateral of a position from the Infrared vault and sends it to the pool
+    /// @param _position The position to unstake
+    /// @param _pool The pool to send the collateral to
+    function unstakePosition(IWasabiPerps.Position memory _position, IInfraredVault _vault, address _pool) external;
+
+    /// @notice Claims the rewards from the Infrared vault
+    /// @param _vault The vault to claim rewards from
+    /// @return tokens The tokens that the rewards are in
+    /// @return amounts The amounts of each token that were claimed
+    function claimRewards(IInfraredVault _vault) external returns (IERC20[] memory, uint256[] memory);
+}

--- a/contracts/bera/IStakingAccount.sol
+++ b/contracts/bera/IStakingAccount.sol
@@ -8,19 +8,32 @@ import "./IInfraredVault.sol";
 interface IStakingAccount {
     error TraderNotAccountHolder();
     error CallerNotFactory();
+    error StakingTypeNotSupported();
+    
+    /// @dev More staking types can be added in the future
+    enum StakingType {
+        INFRARED
+    }
 
-    /// @notice Stakes the collateral of a position in the Infrared vault
+    struct StakingContract {
+        address contractAddress;
+        StakingType stakingType;
+    }
+
+    /// @notice Stakes the collateral of a position in the appropriate staking contract
     /// @param _position The position to stake
-    function stakePosition(IWasabiPerps.Position memory _position, IInfraredVault _vault) external;
+    /// @param _stakingContract The staking contract to stake the position in
+    function stakePosition(IWasabiPerps.Position memory _position, StakingContract memory _stakingContract) external;
 
-    /// @notice Unstakes the collateral of a position from the Infrared vault and sends it to the pool
+    /// @notice Unstakes the collateral of a position from the appropriate staking contract and sends it to the pool
     /// @param _position The position to unstake
+    /// @param _stakingContract The staking contract to unstake the position from
     /// @param _pool The pool to send the collateral to
-    function unstakePosition(IWasabiPerps.Position memory _position, IInfraredVault _vault, address _pool) external;
+    function unstakePosition(IWasabiPerps.Position memory _position, StakingContract memory _stakingContract, address _pool) external;
 
-    /// @notice Claims the rewards from the Infrared vault
-    /// @param _vault The vault to claim rewards from
+    /// @notice Claims the rewards from the appropriate staking contract
+    /// @param _stakingContract The staking contract to claim rewards from
     /// @return tokens The tokens that the rewards are in
     /// @return amounts The amounts of each token that were claimed
-    function claimRewards(IInfraredVault _vault) external returns (IERC20[] memory, uint256[] memory);
+    function claimRewards(StakingContract memory _stakingContract) external returns (IERC20[] memory, uint256[] memory);
 }

--- a/contracts/bera/IStakingAccountFactory.sol
+++ b/contracts/bera/IStakingAccountFactory.sol
@@ -47,10 +47,6 @@ interface IStakingAccountFactory {
     /// @param _stakingToken The staking token to claim rewards for
     function claimRewards(address _stakingToken) external;
 
-    /// @notice Returns the StakingAccount for a trader
-    /// @param _user The trader to get the StakingAccount for
-    function getOrCreateStakingAccount(address _user) external returns (IStakingAccount);
-
     /// @notice Sets the vault for a staking token
     /// @param _stakingToken The staking token to set the vault for
     /// @param _stakingContract The staking contract to set

--- a/contracts/bera/IStakingAccountFactory.sol
+++ b/contracts/bera/IStakingAccountFactory.sol
@@ -6,12 +6,33 @@ import "./IStakingAccount.sol";
 
 interface IStakingAccountFactory {
     error CallerNotPool();
-    error VaultNotSetForToken(address _token);
+    error StakingContractNotSetForToken(address _token);
 
     event StakingAccountCreated(address indexed user, address stakingAccount);
-    event StakedPosition(address indexed user, address stakingAccount, uint256 positionId, uint256 collateralAmount);
-    event UnstakedPosition(address indexed user, address stakingAccount, uint256 positionId, uint256 collateralAmount);
-    event StakingRewardsClaimed(address indexed user, address stakingAccount, address rewardToken, uint256 amount);
+    event StakedPosition(
+        address indexed user,
+        address stakingAccount,
+        address stakingContract,
+        IStakingAccount.StakingType stakingType,
+        uint256 positionId,
+        uint256 collateralAmount
+    );
+    event UnstakedPosition(
+        address indexed user,
+        address stakingAccount,
+        address stakingContract,
+        IStakingAccount.StakingType stakingType,
+        uint256 positionId,
+        uint256 collateralAmount
+    );
+    event StakingRewardsClaimed(
+        address indexed user,
+        address stakingAccount,
+        address stakingContract,
+        IStakingAccount.StakingType stakingType,
+        address rewardToken,
+        uint256 amount
+    );
 
     /// @notice Stakes the collateral of a position in the Infrared vault via the trader's StakingAccount
     /// @param _position The position to stake
@@ -31,8 +52,9 @@ interface IStakingAccountFactory {
 
     /// @notice Sets the vault for a staking token
     /// @param _stakingToken The staking token to set the vault for
-    /// @param _vault The vault to set
-    function setVaultForStakingToken(address _stakingToken, address _vault) external;
+    /// @param _stakingContract The staking contract to set
+    /// @param _stakingType The type of the staking contract
+    function setStakingContractForToken(address _stakingToken, address _stakingContract, IStakingAccount.StakingType _stakingType) external;
 
     /// @notice Upgrades the StakingAccount proxies to a new implementation
     /// @param _newImplementation The new implementation to upgrade to

--- a/contracts/bera/IStakingAccountFactory.sol
+++ b/contracts/bera/IStakingAccountFactory.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "../IWasabiPerps.sol";
+import "./IStakingAccount.sol";
+interface IStakingAccountFactory {
+    error CallerNotPool();
+    error VaultNotSetForToken(address _token);
+
+    event StakingAccountCreated(address indexed user, address stakingAccount);
+    event StakedPosition(address indexed user, address stakingAccount, uint256 positionId, uint256 collateralAmount);
+    event UnstakedPosition(address indexed user, address stakingAccount, uint256 positionId, uint256 collateralAmount);
+    event StakingRewardsClaimed(address indexed user, address stakingAccount, address indexed rewardToken, uint256 amount);
+
+    /// @notice Stakes the collateral of a position in the Infrared vault via the trader's StakingAccount
+    /// @param _position The position to stake
+    function stakePosition(IWasabiPerps.Position memory _position) external;
+
+    /// @notice Unstakes the collateral of a position from the Infrared vault and sends it back to the pool via the trader's StakingAccount
+    /// @param _position The position to unstake
+    function unstakePosition(IWasabiPerps.Position memory _position) external;
+
+    /// @notice Claims the rewards from the Infrared vault
+    /// @param _stakingToken The staking token to claim rewards for
+    function claimRewards(address _stakingToken) external;
+
+    /// @notice Returns the StakingAccount for a trader
+    /// @param _user The trader to get the StakingAccount for
+    function getOrCreateStakingAccount(address _user) external returns (IStakingAccount);
+
+    /// @notice Upgrades the StakingAccount proxies to a new implementation
+    /// @param _newImplementation The new implementation to upgrade to
+    function upgradeBeacon(address _newImplementation) external;
+}

--- a/contracts/bera/IStakingAccountFactory.sol
+++ b/contracts/bera/IStakingAccountFactory.sol
@@ -7,6 +7,7 @@ import "./IStakingAccount.sol";
 interface IStakingAccountFactory {
     error CallerNotPool();
     error StakingContractNotSetForToken(address _token);
+    error StakingAccountNotDeployed(address _user);
 
     event StakingAccountCreated(address indexed user, address stakingAccount);
     event StakedPosition(

--- a/contracts/bera/IStakingAccountFactory.sol
+++ b/contracts/bera/IStakingAccountFactory.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.23;
 
 import "../IWasabiPerps.sol";
 import "./IStakingAccount.sol";
+
 interface IStakingAccountFactory {
     error CallerNotPool();
     error VaultNotSetForToken(address _token);
@@ -10,13 +11,13 @@ interface IStakingAccountFactory {
     event StakingAccountCreated(address indexed user, address stakingAccount);
     event StakedPosition(address indexed user, address stakingAccount, uint256 positionId, uint256 collateralAmount);
     event UnstakedPosition(address indexed user, address stakingAccount, uint256 positionId, uint256 collateralAmount);
-    event StakingRewardsClaimed(address indexed user, address stakingAccount, address indexed rewardToken, uint256 amount);
+    event StakingRewardsClaimed(address indexed user, address stakingAccount, address rewardToken, uint256 amount);
 
     /// @notice Stakes the collateral of a position in the Infrared vault via the trader's StakingAccount
     /// @param _position The position to stake
     function stakePosition(IWasabiPerps.Position memory _position) external;
 
-    /// @notice Unstakes the collateral of a position, sends it back to the pool via the trader's StakingAccount, and claims rewards
+    /// @notice Unstakes the collateral of a position, sends it to the pool via the StakingAccount, and claims rewards
     /// @param _position The position to unstake
     function unstakePosition(IWasabiPerps.Position memory _position) external;
 
@@ -27,6 +28,11 @@ interface IStakingAccountFactory {
     /// @notice Returns the StakingAccount for a trader
     /// @param _user The trader to get the StakingAccount for
     function getOrCreateStakingAccount(address _user) external returns (IStakingAccount);
+
+    /// @notice Sets the vault for a staking token
+    /// @param _stakingToken The staking token to set the vault for
+    /// @param _vault The vault to set
+    function setVaultForStakingToken(address _stakingToken, address _vault) external;
 
     /// @notice Upgrades the StakingAccount proxies to a new implementation
     /// @param _newImplementation The new implementation to upgrade to

--- a/contracts/bera/IStakingAccountFactory.sol
+++ b/contracts/bera/IStakingAccountFactory.sol
@@ -16,7 +16,7 @@ interface IStakingAccountFactory {
     /// @param _position The position to stake
     function stakePosition(IWasabiPerps.Position memory _position) external;
 
-    /// @notice Unstakes the collateral of a position from the Infrared vault and sends it back to the pool via the trader's StakingAccount
+    /// @notice Unstakes the collateral of a position, sends it back to the pool via the trader's StakingAccount, and claims rewards
     /// @param _position The position to unstake
     function unstakePosition(IWasabiPerps.Position memory _position) external;
 

--- a/contracts/bera/StakingAccount.sol
+++ b/contracts/bera/StakingAccount.sol
@@ -32,6 +32,7 @@ contract StakingAccount is IStakingAccount, OwnableUpgradeable, ReentrancyGuardU
         _;
     }
 
+    /// @dev Checks if the caller is the StakingAccountFactory
     modifier onlyFactory() {
         if (msg.sender != address(factory)) revert CallerNotFactory();
         _;

--- a/contracts/bera/StakingAccount.sol
+++ b/contracts/bera/StakingAccount.sol
@@ -59,25 +59,38 @@ contract StakingAccount is IStakingAccount, OwnableUpgradeable, ReentrancyGuardU
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @inheritdoc IStakingAccount
-    function stakePosition(IWasabiPerps.Position memory _position, IInfraredVault _vault) external onlyFactory onlyAccountHolder(_position.trader) {
+    function stakePosition(IWasabiPerps.Position memory _position, StakingContract memory _stakingContract) external onlyFactory onlyAccountHolder(_position.trader) {
         IERC20 collateralToken = IERC20(_position.collateralCurrency);
-        collateralToken.forceApprove(address(_vault), _position.collateralAmount);
+        collateralToken.forceApprove(_stakingContract.contractAddress, _position.collateralAmount);
 
-        _vault.stake(_position.collateralAmount);
+        if (_stakingContract.stakingType == StakingType.INFRARED) {
+            IInfraredVault(_stakingContract.contractAddress).stake(_position.collateralAmount);
+        } else {
+            revert StakingTypeNotSupported();
+        }
     }
 
     /// @inheritdoc IStakingAccount
-    function unstakePosition(IWasabiPerps.Position memory _position, IInfraredVault _vault, address _pool) external onlyFactory onlyAccountHolder(_position.trader) {
-        _vault.withdraw(_position.collateralAmount);
+    function unstakePosition(IWasabiPerps.Position memory _position, StakingContract memory _stakingContract, address _pool) external onlyFactory onlyAccountHolder(_position.trader) {
+        if (_stakingContract.stakingType == StakingType.INFRARED) {
+            IInfraredVault(_stakingContract.contractAddress).withdraw(_position.collateralAmount);
+        } else {
+            revert StakingTypeNotSupported();
+        }
 
         IERC20 collateralToken = IERC20(_position.collateralCurrency);
         collateralToken.safeTransfer(_pool, _position.collateralAmount);
     }
 
     /// @inheritdoc IStakingAccount
-    function claimRewards(IInfraredVault _vault) external onlyFactory returns (IERC20[] memory, uint256[] memory) {
-        address[] memory allRewardTokens = _vault.getAllRewardTokens();
-        _vault.getReward();
+    function claimRewards(StakingContract memory _stakingContract) external onlyFactory returns (IERC20[] memory, uint256[] memory) {
+        address[] memory allRewardTokens;
+        if (_stakingContract.stakingType == StakingType.INFRARED) {
+            allRewardTokens = IInfraredVault(_stakingContract.contractAddress).getAllRewardTokens();
+            IInfraredVault(_stakingContract.contractAddress).getReward();
+        } else {
+            revert StakingTypeNotSupported();
+        }
         
         // Use dynamic arrays to store tokens and amounts
         IERC20[] memory tempTokens = new IERC20[](allRewardTokens.length);

--- a/contracts/bera/StakingAccountFactory.sol
+++ b/contracts/bera/StakingAccountFactory.sol
@@ -92,7 +92,7 @@ contract StakingAccountFactory is
         collateralToken.safeTransferFrom(msg.sender, address(stakingAccount), _position.collateralAmount);
 
         stakingAccount.stakePosition(_position, stakingContract);
-        
+
         emit StakedPosition(
             _position.trader,
             address(stakingAccount),
@@ -109,8 +109,8 @@ contract StakingAccountFactory is
         IStakingAccount.StakingContract memory stakingContract = tokenToStakingContract[_position.collateralCurrency];
         if (stakingContract.contractAddress == address(0)) revert StakingContractNotSetForToken(_position.collateralCurrency);
 
-        stakingAccount.unstakePosition(_position, stakingContract, msg.sender);
         _claimRewards(_position.collateralCurrency, _position.trader);
+        stakingAccount.unstakePosition(_position, stakingContract, msg.sender);
 
         emit UnstakedPosition(
             _position.trader,

--- a/contracts/bera/StakingAccountFactory.sol
+++ b/contracts/bera/StakingAccountFactory.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "./IStakingAccountFactory.sol";
+import "./StakingAccount.sol";
+import "../admin/PerpManager.sol";
+
+contract StakingAccountFactory is IStakingAccountFactory, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable {
+    using SafeERC20 for IERC20;
+    
+    UpgradeableBeacon public beacon;
+    IWasabiPerps public longPool;
+    IWasabiPerps public shortPool;
+
+    mapping(address => address) public userToStakingAccount;
+    mapping(address => IInfraredVault) public stakingTokenToVault;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         MODIFIERS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Checks if the caller is one of the pool contracts
+    modifier onlyPool() {
+        if (msg.sender != address(longPool)) {
+            // Nested checks save a little gas compared to using &&
+            if (msg.sender != address(shortPool)) revert CallerNotPool();
+        }
+        _;
+    }
+
+    /// @dev Checks if the caller is an admin
+    modifier onlyAdmin() {
+        _getManager().isAdmin(msg.sender);
+        _;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        INITIALIZER                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the factory
+    /// @param _manager The PerpManager contract
+    /// @param _longPool The BeraLongPool contract
+    /// @param _shortPool The BeraShortPool contract
+    function initialize(PerpManager _manager, IWasabiPerps _longPool, IWasabiPerps _shortPool) public initializer {
+        __UUPSUpgradeable_init();
+        __Ownable_init(address(_manager));
+        __ReentrancyGuard_init();
+
+        beacon = new UpgradeableBeacon(address(new StakingAccount()), address(this));
+        longPool = _longPool;
+        shortPool = _shortPool;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       POOL FUNCTIONS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @inheritdoc IStakingAccountFactory
+    function stakePosition(IWasabiPerps.Position memory _position) public onlyPool {
+        IStakingAccount stakingAccount = getOrCreateStakingAccount(_position.trader);
+        IInfraredVault vault = stakingTokenToVault[_position.collateralCurrency];
+        if (address(vault) == address(0)) revert VaultNotSetForToken(_position.collateralCurrency);
+
+        IERC20 collateralToken = IERC20(_position.collateralCurrency);
+        collateralToken.safeTransferFrom(msg.sender, address(stakingAccount), _position.collateralAmount);
+
+        stakingAccount.stakePosition(_position, vault);
+        emit StakedPosition(_position.trader, address(stakingAccount), _position.id, _position.collateralAmount);
+    }
+
+    /// @inheritdoc IStakingAccountFactory
+    function unstakePosition(IWasabiPerps.Position memory _position) public onlyPool {
+        IStakingAccount stakingAccount = getOrCreateStakingAccount(_position.trader);
+        IInfraredVault vault = stakingTokenToVault[_position.collateralCurrency];
+        if (address(vault) == address(0)) revert VaultNotSetForToken(_position.collateralCurrency);
+
+        stakingAccount.unstakePosition(_position, vault, msg.sender);
+        emit UnstakedPosition(_position.trader, address(stakingAccount), _position.id, _position.collateralAmount);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                           WRITES                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @inheritdoc IStakingAccountFactory
+    function claimRewards(address _stakingToken) public {
+        IStakingAccount stakingAccount = getOrCreateStakingAccount(msg.sender);
+        IInfraredVault vault = stakingTokenToVault[_stakingToken];
+        if (address(vault) == address(0)) revert VaultNotSetForToken(_stakingToken);
+
+        (IERC20[] memory tokens, uint256[] memory amounts) = stakingAccount.claimRewards(vault);
+        for (uint256 i; i < tokens.length; ) {
+            emit StakingRewardsClaimed(msg.sender, address(stakingAccount), address(tokens[i]), amounts[i]);
+            unchecked {
+                i++;
+            }
+        }
+    }
+
+    /// @inheritdoc IStakingAccountFactory
+    function getOrCreateStakingAccount(address _user) public returns (IStakingAccount) {
+        address stakingAccount = userToStakingAccount[_user];
+        if (address(stakingAccount) == address(0)) {
+            stakingAccount = address(new BeaconProxy(
+                address(beacon), 
+                abi.encodeWithSelector(StakingAccount.initialize.selector, _getManager(), _user)
+            ));
+            userToStakingAccount[_user] = stakingAccount;
+            emit StakingAccountCreated(_user, stakingAccount);
+        }
+        return IStakingAccount(stakingAccount);
+    }
+
+    /// @inheritdoc IStakingAccountFactory
+    function upgradeBeacon(address _newImplementation) external onlyAdmin {
+        beacon.upgradeTo(_newImplementation);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      INTERNAL FUNCTIONS                    */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// solhint-disable-next-line no-empty-blocks
+    /// @inheritdoc UUPSUpgradeable
+    function _authorizeUpgrade(address) internal view override onlyAdmin {}
+
+    /// @dev returns the manager of the contract
+    function _getManager() internal view returns (PerpManager) {
+        return PerpManager(owner());
+    }
+}

--- a/contracts/bera/StakingAccountFactory.sol
+++ b/contracts/bera/StakingAccountFactory.sol
@@ -78,6 +78,11 @@ contract StakingAccountFactory is
         tokenToStakingContract[_stakingToken] = IStakingAccount.StakingContract(_stakingContract, _stakingType);
     }
 
+    /// @inheritdoc IStakingAccountFactory
+    function upgradeBeacon(address _newImplementation) external onlyAdmin {
+        beacon.upgradeTo(_newImplementation);
+    }
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                       POOL FUNCTIONS                       */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -141,11 +146,6 @@ contract StakingAccountFactory is
             emit StakingAccountCreated(_user, stakingAccount);
         }
         return IStakingAccount(stakingAccount);
-    }
-
-    /// @inheritdoc IStakingAccountFactory
-    function upgradeBeacon(address _newImplementation) external onlyAdmin {
-        beacon.upgradeTo(_newImplementation);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/bera/StakingAccountFactory.sol
+++ b/contracts/bera/StakingAccountFactory.sol
@@ -12,15 +12,20 @@ import "./IStakingAccountFactory.sol";
 import "./StakingAccount.sol";
 import "../admin/PerpManager.sol";
 
-contract StakingAccountFactory is IStakingAccountFactory, UUPSUpgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable {
+contract StakingAccountFactory is 
+    IStakingAccountFactory, 
+    UUPSUpgradeable, 
+    OwnableUpgradeable, 
+    ReentrancyGuardUpgradeable 
+{
     using SafeERC20 for IERC20;
     
     UpgradeableBeacon public beacon;
     IWasabiPerps public longPool;
     IWasabiPerps public shortPool;
 
-    mapping(address => address) public userToStakingAccount;
-    mapping(address => IInfraredVault) public stakingTokenToVault;
+    mapping(address user => address stakingAccount) public userToStakingAccount;
+    mapping(address stakingToken => IInfraredVault vault) public stakingTokenToVault;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         MODIFIERS                          */
@@ -62,6 +67,15 @@ contract StakingAccountFactory is IStakingAccountFactory, UUPSUpgradeable, Ownab
         beacon = new UpgradeableBeacon(address(new StakingAccount()), address(this));
         longPool = _longPool;
         shortPool = _shortPool;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      ADMIN FUNCTIONS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @inheritdoc IStakingAccountFactory
+    function setVaultForStakingToken(address _stakingToken, address _vault) external onlyAdmin {
+        stakingTokenToVault[_stakingToken] = IInfraredVault(_vault);
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/contracts/blast/BlastLongPool.sol
+++ b/contracts/blast/BlastLongPool.sol
@@ -11,7 +11,7 @@ contract BlastLongPool is WasabiLongPool, AbstractBlastContract {
     /// @param _manager the PerpManager contract
     function initialize(IAddressProvider _addressProvider, PerpManager _manager) public override initializer {
         __AbstractBlastContract_init();
-        __BaseWasabiPool_init(true, _addressProvider, _manager); 
+        __WasabiLongPool_init(_addressProvider, _manager);
     }
 
     /// @dev Claims the collateral yield + gas

--- a/contracts/blast/BlastShortPool.sol
+++ b/contracts/blast/BlastShortPool.sol
@@ -10,7 +10,7 @@ contract BlastShortPool is WasabiShortPool, AbstractBlastContract {
     /// @param _manager the PerpManager contract
     function initialize(IAddressProvider _addressProvider, PerpManager _manager) public override initializer {
         __AbstractBlastContract_init();
-        __BaseWasabiPool_init(false, _addressProvider, _manager);
+        __WasabiShortPool_init(_addressProvider, _manager);
     }
 
     /// @dev Claims the collateral yield + gas

--- a/contracts/mock/MockAddressProviderV2.sol
+++ b/contracts/mock/MockAddressProviderV2.sol
@@ -16,6 +16,7 @@ contract MockAddressProviderV2 is Ownable, IAddressProvider {
     address public feeReceiver;
     address public immutable wethAddress;
     address public liquidationFeeReceiver;
+    address public stakingAccountFactory;
     uint256 public liquidationFeeBps; // deprecated
 
     constructor(
@@ -23,13 +24,15 @@ contract MockAddressProviderV2 is Ownable, IAddressProvider {
         IWasabiRouter _wasabiRouter,
         address _feeReceiver,
         address _wethAddress,
-        address _liquidationFeeReceiver
+        address _liquidationFeeReceiver,
+        address _stakingAccountFactory
     ) Ownable(msg.sender) {
         debtController = _debtController;
         wasabiRouter = _wasabiRouter;
         feeReceiver = _feeReceiver;
         wethAddress = _wethAddress;
         liquidationFeeReceiver = _liquidationFeeReceiver;
+        stakingAccountFactory = _stakingAccountFactory;
         // liquidationFeeBps = 300;
     }
 
@@ -78,6 +81,11 @@ contract MockAddressProviderV2 is Ownable, IAddressProvider {
         return wethAddress;
     }
 
+    /// @inheritdoc IAddressProvider
+    function getStakingAccountFactory() external view returns (address) {
+        return stakingAccountFactory;
+    }
+
     /// @dev sets the debt controller
     /// @param _debtController the debt controller
     function setDebtController(IDebtController _debtController) external onlyOwner {
@@ -94,5 +102,11 @@ contract MockAddressProviderV2 is Ownable, IAddressProvider {
     /// @param _liquidationFeeReceiver the fee receiver
     function setLiquidationFeeReceiver(address _liquidationFeeReceiver) external onlyOwner {
         liquidationFeeReceiver = _liquidationFeeReceiver;
+    }
+
+    /// @dev sets the staking account factory
+    /// @param _stakingAccountFactory the staking account factory
+    function setStakingAccountFactory(address _stakingAccountFactory) external onlyOwner {
+        stakingAccountFactory = _stakingAccountFactory;
     }
 }

--- a/contracts/mock/MockInfrared.sol
+++ b/contracts/mock/MockInfrared.sol
@@ -7,6 +7,7 @@ import {IRewardVaultFactory} from "@berachain/pol-contracts/src/pol/interfaces/I
 
 contract MockInfrared is IInfrared {
     IRewardVaultFactory public rewardVaultFactory;
+    mapping(address asset => IInfraredVault vault) public assetToInfraredVault;
 
     constructor(IRewardVaultFactory _rewardVaultFactory) {
         rewardVaultFactory = _rewardVaultFactory;
@@ -18,6 +19,7 @@ contract MockInfrared is IInfrared {
             rewardVault = rewardVaultFactory.createRewardVault(_asset);
         }
         vault = new MockInfraredVault(_asset, rewardVault);
+        assetToInfraredVault[_asset] = vault;
         emit NewVault(msg.sender, _asset, address(vault));
     }
 

--- a/contracts/mock/MockStakingAccountV2.sol
+++ b/contracts/mock/MockStakingAccountV2.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "../bera/StakingAccount.sol";
+
+contract MockStakingAccountV2 is StakingAccount {
+    uint256 public constant MAGIC_VALUE = 1337;
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -103,6 +103,8 @@ const config: HardhatUserConfig = {
       "BlastLongPool",
       "BlastShortPool",
       "BlastVault",
+      "BeraLongPool",
+      "BeraShortPool",
       "BeraVault",
       "PerpUtils",
       "AddressProvider",

--- a/scripts/berachain/deployStakingAccountFactory.ts
+++ b/scripts/berachain/deployStakingAccountFactory.ts
@@ -1,0 +1,80 @@
+import { toFunctionSelector, getAddress } from "viem";
+import hre from "hardhat";
+import { verifyContract } from "../../utils/verifyContract";
+import { CONFIG } from "./config";
+
+async function main() {
+  const config = CONFIG;
+
+  const longPoolAddress = config.longPool;
+  const addressProviderAddress = config.addressProvider;
+  const longPool = await hre.viem.getContractAt("WasabiLongPool", longPoolAddress);
+  const addressProvider = await hre.viem.getContractAt("AddressProvider", addressProviderAddress);
+  const perpManagerAddress = await longPool.read.owner();
+  const ibgtAddress = "0xac03caba51e17c86c921e1f6cbfbdc91f8bb2e6b";
+  const infraredVaultAddress = "0x75f3be06b02e235f6d0e7ef2d462b29739168301";
+
+  console.log("1. Deploying StakingAccountFactory...");
+  const StakingAccountFactory = await hre.ethers.getContractFactory("StakingAccountFactory");
+  const factoryAddress =
+      await hre.upgrades.deployProxy(
+          StakingAccountFactory,
+          [perpManagerAddress],
+          { kind: 'uups' }
+      )
+      .then(c => c.waitForDeployment())
+      .then(c => c.getAddress()).then(getAddress);
+  console.log(`StakingAccountFactory deployed to ${factoryAddress}`);
+
+  await delay(10_000);
+
+  console.log("2. Verifying StakingAccountFactory...");
+  await verifyContract(factoryAddress, []);
+
+  await delay(10_000);
+
+  console.log("3. Upgrading AddressProvider...");
+  const AddressProvider = await hre.ethers.getContractFactory("AddressProvider");
+  const upgradedAddressProvider = 
+    await hre.upgrades.upgradeProxy(
+      addressProviderAddress, 
+      AddressProvider, 
+      { kind: 'uups' }
+    )
+    .then(c => c.waitForDeployment())
+    .then(c => c.getAddress()).then(getAddress);
+
+  await delay(10_000);
+  const implAddress = getAddress(await hre.upgrades.erc1967.getImplementationAddress(upgradedAddressProvider));
+  console.log(`AddressProvider upgraded to ${implAddress}`);
+
+  await delay(10_000);
+
+  console.log("4. Verifying AddressProvider...");
+  await verifyContract(upgradedAddressProvider, []);
+
+  await delay(10_000);
+
+  console.log("5. Adding StakingAccountFactory to AddressProvider...");
+  await addressProvider.write.setStakingAccountFactory([factoryAddress]);
+  console.log("StakingAccountFactory added to AddressProvider");
+
+  await delay(10_000);
+
+  console.log("6. Adding iBGT Infrared Vault to StakingAccountFactory...");
+  const stakingAccountFactory = await hre.viem.getContractAt("StakingAccountFactory", factoryAddress);
+  await stakingAccountFactory.write.setVaultForStakingToken([ibgtAddress, infraredVaultAddress]);
+
+  console.log("Done")
+}
+
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/berachain/deployStakingAccountFactory.ts
+++ b/scripts/berachain/deployStakingAccountFactory.ts
@@ -63,7 +63,7 @@ async function main() {
 
   console.log("6. Adding iBGT Infrared Vault to StakingAccountFactory...");
   const stakingAccountFactory = await hre.viem.getContractAt("StakingAccountFactory", factoryAddress);
-  await stakingAccountFactory.write.setVaultForStakingToken([ibgtAddress, infraredVaultAddress]);
+  await stakingAccountFactory.write.setStakingContractForToken([ibgtAddress, infraredVaultAddress, 0]);
 
   console.log("Done")
 }

--- a/scripts/berachain/upgradeToBeraLongPool.ts
+++ b/scripts/berachain/upgradeToBeraLongPool.ts
@@ -1,0 +1,37 @@
+import { getAddress } from "viem";
+import hre from "hardhat";
+import { verifyContract } from "../../utils/verifyContract";
+import { CONFIG } from "./config";
+
+async function main() {
+  const currentAddress = getAddress(CONFIG.longPool);
+  const BeraLongPool = await hre.ethers.getContractFactory("BeraLongPool");
+  
+  console.log("1. Upgrading WasabiLongPool to BeraLongPool...");
+  const address =
+    await hre.upgrades.upgradeProxy(
+      currentAddress,
+      BeraLongPool,
+      { redeployImplementation: "always" }
+    )
+    .then(c => c.waitForDeployment())
+    .then(c => c.getAddress()).then(getAddress);
+
+  await delay(10_000);
+  const implAddress = getAddress(await hre.upgrades.erc1967.getImplementationAddress(address));
+  console.log(`WasabiLongPool upgraded to BeraLongPool at ${implAddress}`);
+
+  await delay(10_000);
+  await verifyContract(address);
+}
+
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/berachain/BeraLongPool.test.ts
+++ b/test/berachain/BeraLongPool.test.ts
@@ -336,7 +336,7 @@ describe("BeraLongPool", function () {
             const { position } = await sendStakingOpenPositionRequest();
 
             await expect(wasabiLongPool.write.stakePosition([position], { account: user2.account }))
-                .to.be.rejectedWith("CallerNotTrader", "Cannot stake position for another user");
+                .to.be.rejectedWith("SenderNotTrader", "Cannot stake position for another user");
         })
 
         it("Cannot stake position if already staked", async function () {

--- a/test/berachain/BeraLongPool.test.ts
+++ b/test/berachain/BeraLongPool.test.ts
@@ -37,29 +37,22 @@ describe("BeraLongPool", function () {
         });
 
         it("Should deploy StakingAccount correctly", async function () {
-            const { user1, user2, stakingAccountFactory, sendStakingOpenPositionRequest } = await loadFixture(deployLongPoolMockEnvironment);
+            const { user1, stakingAccountFactory, sendStakingOpenPositionRequest } = await loadFixture(deployLongPoolMockEnvironment);
 
             expect(await stakingAccountFactory.read.userToStakingAccount([user1.account.address])).to.equal(zeroAddress);
-            expect(await stakingAccountFactory.read.userToStakingAccount([user2.account.address])).to.equal(zeroAddress);
 
             // Test deploying a staking account while opening a position
             await sendStakingOpenPositionRequest();
 
             const user1StakingAccountAddress = await stakingAccountFactory.read.userToStakingAccount([user1.account.address]);
             expect(user1StakingAccountAddress).to.not.equal(zeroAddress);
-
-            // Test deploying a staking account directly
-            await stakingAccountFactory.write.getOrCreateStakingAccount([user2.account.address]);
-
-            const user2StakingAccountAddress = await stakingAccountFactory.read.userToStakingAccount([user2.account.address]);
-            expect(user2StakingAccountAddress).to.not.equal(zeroAddress);
         });
 
         it("Should upgrade beacon", async function () {
-            const { stakingAccountFactory, user1, user2, beacon } = await loadFixture(deployLongPoolMockEnvironment);
+            const { stakingAccountFactory, user1, user2, sendStakingOpenPositionRequest } = await loadFixture(deployLongPoolMockEnvironment);
 
-            await stakingAccountFactory.write.getOrCreateStakingAccount([user1.account.address]);
-            await stakingAccountFactory.write.getOrCreateStakingAccount([user2.account.address]);
+            await sendStakingOpenPositionRequest(1n, user1.account);
+            await sendStakingOpenPositionRequest(2n, user2.account);
 
             const user1StakingAccountAddress = await stakingAccountFactory.read.userToStakingAccount([user1.account.address]);
             const user2StakingAccountAddress = await stakingAccountFactory.read.userToStakingAccount([user2.account.address]);

--- a/test/berachain/BeraLongPool.test.ts
+++ b/test/berachain/BeraLongPool.test.ts
@@ -1,0 +1,103 @@
+import {
+    time,
+    loadFixture,
+} from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
+import hre from "hardhat";
+import { expect } from "chai";
+import { parseEther, zeroAddress, maxUint256 } from "viem";
+import { deployLongPoolMockEnvironment } from "./berachainFixtures";
+import { getBalance, takeBalanceSnapshot } from "../utils/StateUtils";
+
+describe("BeraLongPool", function () {
+    describe("Deployment", function () {
+        it("Should deploy StakingAccountFactory correctly", async function () {
+            const { addressProvider, stakingAccountFactory, beacon, ibgt, ibgtInfraredVault } = await loadFixture(deployLongPoolMockEnvironment);
+
+            expect(await addressProvider.read.getStakingAccountFactory()).to.equal(stakingAccountFactory.address);
+            expect(await stakingAccountFactory.read.beacon()).to.equal(beacon.address);
+            expect(await stakingAccountFactory.read.stakingTokenToVault([ibgt.address])).to.equal(ibgtInfraredVault.address);
+        });
+
+        it("Should deploy StakingAccount correctly", async function () {
+            const { user1, user2, stakingAccountFactory, sendStakingOpenPositionRequest } = await loadFixture(deployLongPoolMockEnvironment);
+
+            expect(await stakingAccountFactory.read.userToStakingAccount([user1.account.address])).to.equal(zeroAddress);
+            expect(await stakingAccountFactory.read.userToStakingAccount([user2.account.address])).to.equal(zeroAddress);
+
+            // Test deploying a staking account while opening a position
+            await sendStakingOpenPositionRequest();
+
+            const user1StakingAccountAddress = await stakingAccountFactory.read.userToStakingAccount([user1.account.address]);
+            expect(user1StakingAccountAddress).to.not.equal(zeroAddress);
+
+            // Test deploying a staking account directly
+            await stakingAccountFactory.write.getOrCreateStakingAccount([user2.account.address]);
+
+            const user2StakingAccountAddress = await stakingAccountFactory.read.userToStakingAccount([user2.account.address]);
+            expect(user2StakingAccountAddress).to.not.equal(zeroAddress);
+        });
+    });
+
+    describe("Leveraged Staking", function () {
+        it("Should stake a position", async function () {
+            const { user1, wasabiLongPool, stakingAccountFactory, sendStakingOpenPositionRequest, openPositionRequest, totalAmountIn, ibgt, ibgtInfraredVault, ibgtRewardVault } = await loadFixture(deployLongPoolMockEnvironment);
+
+            const { position } = await sendStakingOpenPositionRequest();
+
+            const positionOpenedEvents = await wasabiLongPool.getEvents.PositionOpened();
+            expect(positionOpenedEvents).to.have.lengthOf(1);
+            const positionOpenedEvent = positionOpenedEvents[0].args;
+
+            expect(positionOpenedEvent.positionId).to.equal(openPositionRequest.id);
+            expect(positionOpenedEvent.downPayment).to.equal(totalAmountIn - positionOpenedEvent.feesToBePaid!);
+            expect(positionOpenedEvent.principal).to.equal(openPositionRequest.principal);
+            expect(positionOpenedEvent.collateralAmount).to.equal(await ibgt.read.balanceOf([ibgtRewardVault.address]));
+            expect(positionOpenedEvent.collateralAmount).to.greaterThanOrEqual(openPositionRequest.minTargetAmount);
+
+            const user1StakingAccountAddress = await stakingAccountFactory.read.userToStakingAccount([user1.account.address]);
+            expect(user1StakingAccountAddress).to.not.equal(zeroAddress);
+
+            const stakedEvents = await ibgtInfraredVault.getEvents.Staked();
+            expect(stakedEvents).to.have.lengthOf(1);
+            const stakedEvent = stakedEvents[0].args;
+
+            expect(stakedEvent.amount).to.equal(positionOpenedEvent.collateralAmount);
+            expect(stakedEvent.user).to.equal(user1StakingAccountAddress);
+
+            expect(await wasabiLongPool.read.isPositionStaked([position.id])).to.equal(true);
+            expect(await ibgt.read.balanceOf([wasabiLongPool.address])).to.equal(0n);
+        });
+
+        it("Should stake a position after opening", async function () {
+            const { user1, wasabiLongPool, stakingAccountFactory, sendDefaultOpenPositionRequest, openPositionRequest, totalAmountIn, ibgt, ibgtInfraredVault, ibgtRewardVault } = await loadFixture(deployLongPoolMockEnvironment);
+
+            const { position } = await sendDefaultOpenPositionRequest();
+
+            const positionOpenedEvents = await wasabiLongPool.getEvents.PositionOpened();
+            expect(positionOpenedEvents).to.have.lengthOf(1);
+            const positionOpenedEvent = positionOpenedEvents[0].args;
+
+            expect(positionOpenedEvent.positionId).to.equal(openPositionRequest.id);
+            expect(positionOpenedEvent.downPayment).to.equal(totalAmountIn - positionOpenedEvent.feesToBePaid!);
+            expect(positionOpenedEvent.principal).to.equal(openPositionRequest.principal);
+            expect(positionOpenedEvent.collateralAmount).to.equal(await ibgt.read.balanceOf([wasabiLongPool.address]));
+            expect(positionOpenedEvent.collateralAmount).to.greaterThanOrEqual(openPositionRequest.minTargetAmount);
+            
+            await wasabiLongPool.write.stakePosition([position], { account: user1.account });
+
+            const user1StakingAccountAddress = await stakingAccountFactory.read.userToStakingAccount([user1.account.address]);
+            expect(user1StakingAccountAddress).to.not.equal(zeroAddress);
+
+            const stakedEvents = await ibgtInfraredVault.getEvents.Staked();
+            expect(stakedEvents).to.have.lengthOf(1);
+            const stakedEvent = stakedEvents[0].args;
+
+            expect(stakedEvent.amount).to.equal(positionOpenedEvent.collateralAmount);
+            expect(stakedEvent.user).to.equal(user1StakingAccountAddress);
+
+            expect(await wasabiLongPool.read.isPositionStaked([position.id])).to.equal(true);
+            expect(await ibgt.read.balanceOf([wasabiLongPool.address])).to.equal(0n);
+            expect(await ibgt.read.balanceOf([ibgtRewardVault.address])).to.equal(position.collateralAmount);
+        });
+    });
+});

--- a/test/berachain/BeraLongPool.test.ts
+++ b/test/berachain/BeraLongPool.test.ts
@@ -7,6 +7,8 @@ import { expect } from "chai";
 import { parseEther, zeroAddress, maxUint256 } from "viem";
 import { deployLongPoolMockEnvironment } from "./berachainFixtures";
 import { getBalance, takeBalanceSnapshot } from "../utils/StateUtils";
+import { PayoutType } from "../utils/PerpStructUtils";
+import { getApproveAndSwapFunctionCallData } from "../utils/SwapUtils";
 
 describe("BeraLongPool", function () {
     describe("Deployment", function () {
@@ -38,7 +40,7 @@ describe("BeraLongPool", function () {
         });
     });
 
-    describe("Leveraged Staking", function () {
+    describe("Open Position w/ Leveraged Staking", function () {
         it("Should stake a position", async function () {
             const { user1, wasabiLongPool, stakingAccountFactory, sendStakingOpenPositionRequest, openPositionRequest, totalAmountIn, ibgt, ibgtInfraredVault, ibgtRewardVault } = await loadFixture(deployLongPoolMockEnvironment);
 
@@ -99,5 +101,250 @@ describe("BeraLongPool", function () {
             expect(await ibgt.read.balanceOf([wasabiLongPool.address])).to.equal(0n);
             expect(await ibgt.read.balanceOf([ibgtRewardVault.address])).to.equal(position.collateralAmount);
         });
+    });
+
+    describe("Close Staked Position", function () {
+        it("Price Not Changed", async function () {
+            const { user1, wasabiLongPool, sendStakingOpenPositionRequest, createSignedClosePositionRequest, computeMaxInterest, wbera, ibgt, ibgtRewardVault, vault, feeReceiver, publicClient } = await loadFixture(deployLongPoolMockEnvironment);
+
+            const { position } = await sendStakingOpenPositionRequest();
+            
+            await time.increase(86400n); // 1 day later
+
+            const { request, signature } = await createSignedClosePositionRequest({ position, interest: 0n });
+
+            const traderBalanceBefore = await publicClient.getBalance({address: user1.account.address });
+            const vaultBalanceBefore = await getBalance(publicClient, wbera.address, vault.address);
+            const feeReceiverBalanceBefore = await publicClient.getBalance({address: feeReceiver });
+
+            const maxInterest = await computeMaxInterest(position);
+            
+            const hash = await wasabiLongPool.write.closePosition([PayoutType.UNWRAPPED, request, signature], { account: user1.account });
+
+            const traderBalanceAfter = await publicClient.getBalance({address: user1.account.address });
+            const vaultBalanceAfter = await getBalance(publicClient, wbera.address, vault.address);
+            const feeReceiverBalanceAfter = await publicClient.getBalance({address: feeReceiver });
+
+            // Checks
+            const events = await wasabiLongPool.getEvents.PositionClosed();
+            expect(events).to.have.lengthOf(1);
+            const closePositionEvent = events[0].args;
+            const totalFeesPaid = closePositionEvent.feeAmount! + position.feesToBePaid;
+
+            expect(closePositionEvent.id).to.equal(position.id);
+            expect(closePositionEvent.principalRepaid!).to.equal(position.principal);
+            expect(closePositionEvent.interestPaid!).to.equal(maxInterest, "If given interest value is 0, should use max interest");
+            expect(vaultBalanceBefore + closePositionEvent.principalRepaid! + closePositionEvent.interestPaid!).to.equal(vaultBalanceAfter);
+
+            const totalReturn = closePositionEvent.payout! + closePositionEvent.interestPaid! + closePositionEvent.feeAmount! - position.downPayment;
+            expect(totalReturn).to.equal(0, "Total return should be 0 on no price change");
+
+            expect(await wasabiLongPool.read.isPositionStaked([position.id])).to.equal(false, "Position should not be staked");
+            expect(await ibgt.read.balanceOf([wasabiLongPool.address])).to.equal(0n, "Pool should not have any collateral left");
+            expect(await ibgt.read.balanceOf([ibgtRewardVault.address])).to.equal(0n, "Reward vault should not have any staked collateral left");
+
+            // Check trader has been paid
+            const gasUsed = await publicClient.getTransactionReceipt({hash}).then(r => r.gasUsed * r.effectiveGasPrice);
+            expect(traderBalanceAfter - traderBalanceBefore + gasUsed).to.equal(closePositionEvent.payout!);
+
+            // Check fees have been paid
+            expect(feeReceiverBalanceAfter - feeReceiverBalanceBefore).to.equal(totalFeesPaid);
+        });
+
+        it("Price Increased", async function () {
+            const { sendStakingOpenPositionRequest, createSignedClosePositionRequest, owner, publicClient, wasabiLongPool, user1, ibgt, ibgtRewardVault, mockSwap, feeReceiver, initialPrice, wbera, vault } = await loadFixture(deployLongPoolMockEnvironment);
+
+            // Open Position
+            const {position} = await sendStakingOpenPositionRequest();
+
+            await time.increase(86400n); // 1 day later
+            await mockSwap.write.setPrice([ibgt.address, wbera.address, initialPrice * 2n]); // Price doubled
+
+            // Close Position
+            const { request, signature } = await createSignedClosePositionRequest({position});
+
+            const traderBalanceBefore = await publicClient.getBalance({address: user1.account.address });
+            const vaultBalanceBefore = await getBalance(publicClient, wbera.address, vault.address);
+            const feeReceiverBalanceBefore = await publicClient.getBalance({address: feeReceiver });
+
+            const hash = await wasabiLongPool.write.closePosition([PayoutType.UNWRAPPED, request, signature], { account: user1.account });
+
+            const traderBalanceAfter = await publicClient.getBalance({address: user1.account.address });
+            const vaultBalanceAfter = await getBalance(publicClient, wbera.address, vault.address);
+            const feeReceiverBalanceAfter = await publicClient.getBalance({address: feeReceiver });
+
+            // Checks
+            const events = await wasabiLongPool.getEvents.PositionClosed();
+            expect(events).to.have.lengthOf(1);
+            const closePositionEvent = events[0].args;
+            const totalFeesPaid = closePositionEvent.feeAmount! + position.feesToBePaid;
+
+            expect(closePositionEvent.id).to.equal(position.id);
+            expect(closePositionEvent.principalRepaid!).to.equal(position.principal);
+            expect(vaultBalanceBefore + closePositionEvent.principalRepaid! + closePositionEvent.interestPaid!).to.equal(vaultBalanceAfter);
+
+            const totalReturn = closePositionEvent.payout! + closePositionEvent.interestPaid! + closePositionEvent.feeAmount!;
+            expect(totalReturn).to.equal(position.downPayment * 5n, "on 2x price increase, total return should be 4x down payment");
+
+            expect(await ibgt.read.balanceOf([wasabiLongPool.address])).to.equal(0n, "Pool should not have any collateral left");
+            expect(await ibgt.read.balanceOf([ibgtRewardVault.address])).to.equal(0n, "Reward vault should not have any staked collateral left");
+
+            // Check trader has been paid
+            const gasUsed = await publicClient.getTransactionReceipt({hash}).then(r => r.gasUsed * r.effectiveGasPrice);
+            expect(traderBalanceAfter - traderBalanceBefore + gasUsed).to.equal(closePositionEvent.payout!);
+
+            // Check fees have been paid
+            expect(feeReceiverBalanceAfter - feeReceiverBalanceBefore).to.equal(totalFeesPaid);
+        });
+
+        it("Price Decreased", async function () {
+            const { sendStakingOpenPositionRequest, createSignedClosePositionRequest, publicClient, wasabiLongPool, user1, ibgt, ibgtRewardVault, mockSwap, feeReceiver, initialPrice, wbera, vault } = await loadFixture(deployLongPoolMockEnvironment);
+
+            // Open Position
+            const {position} = await sendStakingOpenPositionRequest();
+
+            await time.increase(86400n); // 1 day later
+            await mockSwap.write.setPrice([ibgt.address, wbera.address, initialPrice * 8n / 10n]); // Price fell 20%
+
+            // Close Position
+            const { request, signature } = await createSignedClosePositionRequest({position});
+
+            const traderBalanceBefore = await publicClient.getBalance({address: user1.account.address });
+            const vaultBalanceBefore = await getBalance(publicClient, wbera.address, vault.address);
+            const feeReceiverBalanceBefore = await publicClient.getBalance({address: feeReceiver });
+
+            const hash = await wasabiLongPool.write.closePosition([PayoutType.UNWRAPPED, request, signature], { account: user1.account });
+
+            const traderBalanceAfter = await publicClient.getBalance({address: user1.account.address });
+            const vaultBalanceAfter = await getBalance(publicClient, wbera.address, vault.address);
+            const feeReceiverBalanceAfter = await publicClient.getBalance({address: feeReceiver });
+
+            // Checks
+            const events = await wasabiLongPool.getEvents.PositionClosed();
+            expect(events).to.have.lengthOf(1);
+            const closePositionEvent = events[0].args;
+            const totalFeesPaid = closePositionEvent.feeAmount! + position.feesToBePaid;
+
+            expect(closePositionEvent.id).to.equal(position.id);
+            expect(closePositionEvent.principalRepaid!).to.equal(position.principal);
+            expect(vaultBalanceBefore + closePositionEvent.principalRepaid! + closePositionEvent.interestPaid!).to.equal(vaultBalanceAfter);
+
+            const totalReturn = closePositionEvent.payout! + closePositionEvent.interestPaid! + closePositionEvent.feeAmount! - position.downPayment;
+            expect(totalReturn).to.equal(position.downPayment / -5n * 4n, "on 20% price decrease, total return should be -20% * leverage (4) * down payment");
+
+            expect(await ibgt.read.balanceOf([wasabiLongPool.address])).to.equal(0n, "Pool should not have any collateral left");
+            expect(await ibgt.read.balanceOf([ibgtRewardVault.address])).to.equal(0n, "Reward vault should not have any staked collateral left");
+
+            // Check trader has been paid
+            const gasUsed = await publicClient.getTransactionReceipt({hash}).then(r => r.gasUsed * r.effectiveGasPrice);
+            expect(traderBalanceAfter - traderBalanceBefore + gasUsed).to.equal(closePositionEvent.payout!);
+
+            // Check fees have been paid
+            expect(feeReceiverBalanceAfter - feeReceiverBalanceBefore).to.equal(totalFeesPaid);
+        });
+    });
+
+    describe("Liquidate Staked Position", function () {
+        it("Liquidate", async function () {
+            const { sendStakingOpenPositionRequest, computeMaxInterest, vault, publicClient, wasabiLongPool, user1, ibgt, ibgtRewardVault, mockSwap, feeReceiver, liquidationFeeReceiver, wbera, liquidator, computeLiquidationPrice } = await loadFixture(deployLongPoolMockEnvironment);
+            // Open Position
+            const {position} = await sendStakingOpenPositionRequest();
+
+            await time.increase(86400n); // 1 day later
+
+            // Liquidate Position
+            const functionCallDataList = getApproveAndSwapFunctionCallData(mockSwap.address, ibgt.address, wbera.address, position.collateralAmount);
+
+            const interest = await computeMaxInterest(position);
+            const liquidationPrice = await computeLiquidationPrice(position);
+
+            // If the liquidation price is not reached, should revert
+            await mockSwap.write.setPrice([ibgt.address, wbera.address, liquidationPrice + 1n]); 
+            await expect(wasabiLongPool.write.liquidatePosition([PayoutType.UNWRAPPED, interest, position, functionCallDataList], { account: liquidator.account }))
+                .to.be.rejectedWith("LiquidationThresholdNotReached", "Cannot liquidate position if liquidation price is not reached");
+
+            // Liquidate
+            await mockSwap.write.setPrice([ibgt.address, wbera.address, liquidationPrice]); 
+
+            const balancesBefore = await takeBalanceSnapshot(publicClient, wbera.address, vault.address, user1.account.address, feeReceiver, liquidationFeeReceiver);
+            const traderBalanceBefore = await publicClient.getBalance({address: user1.account.address });
+            const feeReceiverBalanceBefore = await publicClient.getBalance({address: feeReceiver });
+            const liquidationFeeReceiverBalanceBefore = await publicClient.getBalance({address: liquidationFeeReceiver });            
+
+            const hash = await wasabiLongPool.write.liquidatePosition([PayoutType.UNWRAPPED, interest, position, functionCallDataList], { account: liquidator.account });
+
+            const balancesAfter = await takeBalanceSnapshot(publicClient, wbera.address, vault.address, user1.account.address, feeReceiver);
+            const traderBalanceAfter = await publicClient.getBalance({address: user1.account.address });
+            const feeReceiverBalanceAfter = await publicClient.getBalance({address: feeReceiver });
+            const liquidationFeeReceiverBalanceAfter = await publicClient.getBalance({address: liquidationFeeReceiver });
+            // Checks
+            const events = await wasabiLongPool.getEvents.PositionLiquidated();
+            expect(events).to.have.lengthOf(1);
+            const liquidatePositionEvent = events[0].args;
+            const totalFeesPaid = liquidatePositionEvent.feeAmount! + position.feesToBePaid;
+
+            expect(liquidatePositionEvent.id).to.equal(position.id);
+            expect(liquidatePositionEvent.principalRepaid!).to.equal(position.principal);
+            expect(await ibgt.read.balanceOf([wasabiLongPool.address])).to.equal(0n, "Pool should not have any collateral left");
+            expect(await ibgt.read.balanceOf([ibgtRewardVault.address])).to.equal(0n, "Reward vault should not have any staked collateral left");
+
+            expect(balancesBefore.get(vault.address) + liquidatePositionEvent.principalRepaid! + liquidatePositionEvent.interestPaid!).to.equal(balancesAfter.get(vault.address)!);
+
+            // Check trader has been paid
+            expect(traderBalanceAfter - traderBalanceBefore).to.equal(liquidatePositionEvent.payout!);
+
+            // Check fees have been paid
+            expect(feeReceiverBalanceAfter - feeReceiverBalanceBefore).to.equal(totalFeesPaid);
+
+            // Check liquidation fee receiver balance
+            const liquidationFeeExpected = position.downPayment * 5n / 100n;
+            expect(liquidationFeeReceiverBalanceAfter - liquidationFeeReceiverBalanceBefore).to.equal(liquidationFeeExpected);
+        });
+
+        it("Liquidate with no payout", async function () {
+            const { sendStakingOpenPositionRequest, computeMaxInterest, wasabiLongPool, ibgt, mockSwap, wbera, liquidator, computeLiquidationPrice } = await loadFixture(deployLongPoolMockEnvironment);
+            // Open Position
+            const {position} = await sendStakingOpenPositionRequest();
+    
+            await time.increase(86400n); // 1 day later
+    
+            // Liquidate Position
+            const functionCallDataList = getApproveAndSwapFunctionCallData(mockSwap.address, ibgt.address, wbera.address, position.collateralAmount);
+    
+            const interest = await computeMaxInterest(position);
+            const liquidationPrice = await computeLiquidationPrice(position);
+    
+            // If the liquidation price is not reached, should revert
+            await mockSwap.write.setPrice([ibgt.address, wbera.address, liquidationPrice + 1n]); 
+            await expect(wasabiLongPool.write.liquidatePosition([PayoutType.UNWRAPPED, interest, position, functionCallDataList], { account: liquidator.account }))
+                .to.be.rejectedWith("LiquidationThresholdNotReached", "Cannot liquidate position if liquidation price is not reached");
+    
+            await mockSwap.write.setPrice([ibgt.address, wbera.address, liquidationPrice / 2n]); 
+    
+            await wasabiLongPool.write.liquidatePosition([PayoutType.UNWRAPPED, interest, position, functionCallDataList], { account: liquidator.account });
+            // Checks for no payout
+            const events = await wasabiLongPool.getEvents.PositionLiquidated();
+            expect(events).to.have.lengthOf(1);
+            const liquidatePositionEvent = events[0].args;
+            expect(liquidatePositionEvent.payout!).to.equal(0n);
+        });
+    });
+
+    describe("Validations", function () {
+        it("Cannot stake position for another user", async function () {
+            const { sendStakingOpenPositionRequest, user2, wasabiLongPool } = await loadFixture(deployLongPoolMockEnvironment);
+            const { position } = await sendStakingOpenPositionRequest();
+
+            await expect(wasabiLongPool.write.stakePosition([position], { account: user2.account }))
+                .to.be.rejectedWith("CallerNotTrader", "Cannot stake position for another user");
+        })
+
+        it("Cannot stake position if already staked", async function () {
+            const { sendStakingOpenPositionRequest, user1, wasabiLongPool } = await loadFixture(deployLongPoolMockEnvironment);
+            const { position } = await sendStakingOpenPositionRequest();
+
+            await expect(wasabiLongPool.write.stakePosition([position], { account: user1.account }))
+                .to.be.rejectedWith("PositionAlreadyStaked", "Cannot stake position if already staked");
+        })
     });
 });

--- a/test/berachain/BeraVault.test.ts
+++ b/test/berachain/BeraVault.test.ts
@@ -1,14 +1,10 @@
-import {
-    time,
-    loadFixture,
-} from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import hre from "hardhat";
 import { expect } from "chai";
-import { parseEther, zeroAddress, maxUint256, getAddress } from "viem";
-import { deployLongPoolMockEnvironment, validatorPubKey } from "./berachainFixtures";
+import { parseEther, zeroAddress, maxUint256 } from "viem";
+import { deployLongPoolMockEnvironment } from "./berachainFixtures";
 import { getBalance, takeBalanceSnapshot } from "../utils/StateUtils";
-import { PayoutType } from "../utils/PerpStructUtils";
-import { checkDepositEvents, checkMigrateTransferEvents, checkWithdrawEvents, distributeRewards, splitSharesWithFee } from "./berachainHelpers";
+import { checkDepositEvents, checkWithdrawEvents, splitSharesWithFee } from "./berachainHelpers";
 
 describe("BeraVault", function () {
     describe("Deployment", function () {

--- a/test/berachain/berachainFixtures.ts
+++ b/test/berachain/berachainFixtures.ts
@@ -228,7 +228,7 @@ export async function deployVault(longPoolAddress: Address, shortPoolAddress: Ad
     return { vault, rewardVault, infraredVault }
 }
 
-export async function deployWasabiLongPool() {
+export async function deployBeraLongPool() {
     const perpManager = await deployPerpManager();
     const addressProviderFixture = await deployAddressProvider();
     const {addressProvider, weth: wbera} = addressProviderFixture;
@@ -239,12 +239,12 @@ export async function deployWasabiLongPool() {
     const [owner, user1, user2] = await hre.viem.getWalletClients();
     const publicClient = await hre.viem.getPublicClient();
 
-    // Deploy WasabiLongPool
-    const contractName = "WasabiLongPool";
-    const WasabiLongPool = await hre.ethers.getContractFactory(contractName);
+    // Deploy BeraLongPool
+    const contractName = "BeraLongPool";
+    const BeraLongPool = await hre.ethers.getContractFactory(contractName);
     const address = 
         await hre.upgrades.deployProxy(
-            WasabiLongPool,
+            BeraLongPool,
             [addressProviderFixture.addressProvider.address, perpManager.manager.address],
             { kind: 'uups'}
         )
@@ -323,17 +323,17 @@ export async function deployWasabiShortPool() {
 
     const wasabiShortPool = await hre.viem.getContractAt(contractName, address);
 
-    // Deploy WasabiLongPool (for USDC deposits on close)
-    const WasabiLongPool = await hre.ethers.getContractFactory("WasabiLongPool");
+    // Deploy BeraLongPool (for USDC deposits on close)
+    const BeraLongPool = await hre.ethers.getContractFactory("BeraLongPool");
     const longPoolAddress = 
         await hre.upgrades.deployProxy(
-            WasabiLongPool,
+            BeraLongPool,
             [addressProviderFixture.addressProvider.address, perpManager.manager.address],
             { kind: 'uups'}
         )
         .then(c => c.waitForDeployment())
         .then(c => c.getAddress()).then(getAddress);
-    const wasabiLongPool = await hre.viem.getContractAt("WasabiLongPool", longPoolAddress);
+    const wasabiLongPool = await hre.viem.getContractAt("BeraLongPool", longPoolAddress);
 
     const uPPG = await hre.viem.deployContract("MockERC20", ["μPudgyPenguins", 'μPPG']);
     const usdc = await hre.viem.deployContract("USDC", []);
@@ -382,7 +382,7 @@ export async function deployWasabiShortPool() {
 }
 
 export async function deployLongPoolMockEnvironment() {
-    const wasabiLongPoolFixture = await deployWasabiLongPool();
+    const wasabiLongPoolFixture = await deployBeraLongPool();
     const {tradeFeeValue, contractName, wasabiLongPool, user1, user2, publicClient, feeDenominator, debtController, wbera, orderSigner} = wasabiLongPoolFixture;
     const [owner] = await hre.viem.getWalletClients();
 

--- a/test/berachain/berachainFixtures.ts
+++ b/test/berachain/berachainFixtures.ts
@@ -501,7 +501,7 @@ export async function deployLongPoolMockEnvironment() {
 
     const createSignedClosePositionRequest = async (params: CreateClosePositionRequestParams): Promise<WithSignature<ClosePositionRequest>> => {
         const request = await createClosePositionRequest(params);
-        const signature = await signClosePositionRequest(orderSigner, contractName, wasabiLongPool.address, request);
+        const signature = await signClosePositionRequest(orderSigner, "WasabiLongPool", wasabiLongPool.address, request);
         return { request, signature }
     }
 
@@ -522,7 +522,7 @@ export async function deployLongPoolMockEnvironment() {
     const createSignedClosePositionOrder = async (params: CreateClosePositionOrderParams): Promise<WithSignature<ClosePositionOrder>> => {
         const {traderSigner} = params;
         const order = await createClosePositionOrder(params);
-        const signature = await signClosePositionOrder(traderSigner, contractName, wasabiLongPool.address, order);
+        const signature = await signClosePositionOrder(traderSigner, "WasabiLongPool", wasabiLongPool.address, order);
         return { request: order, signature }
     }
 

--- a/test/berachain/berachainFixtures.ts
+++ b/test/berachain/berachainFixtures.ts
@@ -441,7 +441,7 @@ export async function deployLongPoolMockEnvironment() {
     await wbera.write.approve([wasabiLongPool.address, maxUint256], {account: user2.account});
 
     await addressProvider.write.setStakingAccountFactory([stakingAccountFactory.address], {account: owner.account});
-    await stakingAccountFactory.write.setVaultForStakingToken([ibgt.address, ibgtInfraredVault.address], {account: owner.account});
+    await stakingAccountFactory.write.setStakingContractForToken([ibgt.address, ibgtInfraredVault.address, 0], {account: owner.account});
 
     const openPositionRequest: OpenPositionRequest = {
         id: 1n,

--- a/test/berachain/berachainFixtures.ts
+++ b/test/berachain/berachainFixtures.ts
@@ -3,7 +3,7 @@ import type { Address } from 'abitype'
 import hre from "hardhat";
 import { mine } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { deployAddressProvider, deployPerpManager } from "../fixtures";
-import { parseEther, zeroAddress, getAddress, maxUint256, encodeFunctionData, parseUnits, EncodeFunctionDataReturnType } from "viem";
+import { parseEther, zeroAddress, getAddress, maxUint256, encodeFunctionData, parseUnits, EncodeFunctionDataReturnType, Account } from "viem";
 import { ClosePositionRequest, ClosePositionOrder, OrderType, FunctionCallData, OpenPositionRequest, Position, Vault, WithSignature, getEventPosition, getFee, getValueWithoutFee } from "../utils/PerpStructUtils";
 import { Signer, signClosePositionRequest, signClosePositionOrder, signOpenPositionRequest } from "../utils/SigningUtils";
 import { getApproveAndSwapExactlyOutFunctionCallData, getApproveAndSwapFunctionCallData, getRouterSwapExactlyOutFunctionCallData, getRouterSwapFunctionCallData, getSwapExactlyOutFunctionCallData, getSwapFunctionCallData, getSweepTokenWithFeeCallData, getUnwrapWETH9WithFeeCallData } from "../utils/SwapUtils";
@@ -482,10 +482,10 @@ export async function deployLongPoolMockEnvironment() {
         }
     }
 
-    const sendStakingOpenPositionRequest = async (id?: bigint | undefined) => {
+    const sendStakingOpenPositionRequest = async (id?: bigint | undefined, account?: Account) => {
         const request = id ? {...openPositionRequest, id} : openPositionRequest;
         const signature = await signOpenPositionRequest(orderSigner, "WasabiLongPool", wasabiLongPool.address, request);
-        const hash = await wasabiLongPool.write.openPositionAndStake([request, signature], { account: user1.account });
+        const hash = await wasabiLongPool.write.openPositionAndStake([request, signature], { account: account || user1.account });
         const gasUsed = await publicClient.getTransactionReceipt({hash}).then(r => r.gasUsed * r.effectiveGasPrice);
         const event = (await wasabiLongPool.getEvents.PositionOpened())[0];
         const position: Position = await getEventPosition(event);

--- a/test/berachain/berachainFixtures.ts
+++ b/test/berachain/berachainFixtures.ts
@@ -285,8 +285,18 @@ export async function deployBeraLongPool() {
     const ibgtInfraredVault = await hre.viem.getContractAt("MockInfraredVault", ibgtInfraredVaultAddress);
     const ibgtRewardVaultAddress = await ibgtInfraredVault.read.rewardsVault();
     const ibgtRewardVault = await hre.viem.getContractAt("RewardVault", ibgtRewardVaultAddress);
+
+    // Set up iBGT vault rewards
+    await ibgtInfraredVault.write.addReward([wbera.address, 864000n]);
+    await ibgtInfraredVault.write.addReward([ibgt.address, 864000n]);
+    await wbera.write.deposit([], { value: parseEther("100"), account: owner.account });
+    await wbera.write.approve([ibgtInfraredVault.address, parseEther("100")], {account: owner.account});
+    await ibgt.write.mint([owner.account.address, parseEther("100")]);
+    await ibgt.write.approve([ibgtInfraredVault.address, parseEther("100")], {account: owner.account});
+    await ibgtInfraredVault.write.notifyRewardAmount([wbera.address, parseEther("100")], {account: owner.account});
+    await ibgtInfraredVault.write.notifyRewardAmount([ibgt.address, parseEther("100")], {account: owner.account});
     
-    // Set up rewards
+    // Set up BGT rewards
     await rewardVault.write.setOperator([vault.address], {account: owner.account});
     await rewardVault.write.whitelistIncentiveToken([wbera.address, parseEther("1"), owner.account.address], {account: owner.account});
     const incentiveAmount = parseEther("100");

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -320,7 +320,7 @@ export async function deployAddressProvider() {
     const addressProvider = 
         await hre.viem.deployContract(
             "AddressProvider",
-            [debtControllerFixture.debtController.address, zeroAddress, owner.account.address, wethFixture.wethAddress, user4.account.address]);
+            [debtControllerFixture.debtController.address, zeroAddress, owner.account.address, wethFixture.wethAddress, user4.account.address, zeroAddress]);
     return {
         ...wethFixture,
         ...debtControllerFixture,
@@ -340,7 +340,7 @@ export async function deployAddressProvider2() {
     const addressProvider = 
         await hre.viem.deployContract(
             "MockAddressProviderV2",
-            [debtControllerFixture.debtController.address, zeroAddress, owner.account.address, zeroAddress]);
+            [debtControllerFixture.debtController.address, zeroAddress, owner.account.address, zeroAddress, zeroAddress, zeroAddress]);
     return {
         ...debtControllerFixture,
         addressProvider,


### PR DESCRIPTION
Introduces the following new contracts:

- StakingAccount
  - Per-user contract deployed automatically
  - Stakes and unstakes collateral to/from (iBGT) long positions in the corresponding InfraredVault
  - Accrues rewards for the user and allows them to claim rewards (through the factory)
  - Deployed as a BeaconProxy
- StakingAccountFactory
  - Deploys new StakingAccount contracts for users when necessary
  - Keeps track of which tokens can be staked and in which InfraredVaults
  - Provides a single entry point for pools to stake and unstake, and for users to claim rewards
  - Owns and manages the UpgradeableBeacon
- BeraLongPool (and potentially BeraShortPool)
  - Provides wrapper functions for opening a position and then staking the collateral
  - Keeps track of which positions are staked, since it is also possible to open a position without staking
  - Overrides the `_closePositionInternal` function to unstake (if necessary) before closing
 
Includes the following changes to existing contracts:
- AddressProvider
  - Stores the StakingAccountFactory address
- WasabiLongPool and WasabiShortPool
  - Open position functions return the Position struct