### PR TITLE
Spicy Honey Competition Winners Deposit Contract

### DIFF
--- a/contracts/util/CappedVaultCompetitionDepositor.sol
+++ b/contracts/util/CappedVaultCompetitionDepositor.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "../admin/PerpManager.sol";
+import "../vaults/IWasabiVault.sol";
+
+contract CappedVaultCompetitionDepositor is UUPSUpgradeable, ReentrancyGuardUpgradeable, OwnableUpgradeable {
+    using SafeERC20 for IERC20;
+
+    error AllocationsLengthMismatch();
+    error SenderNotAllocated();
+    error InsufficientBalance();
+    error DepositWindowClosed();
+
+    IWasabiVault public vault;
+    mapping(address => uint256) public depositAllocations;
+
+    /**
+     * @dev Checks if the caller is an admin
+     */
+    modifier onlyAdmin() {
+        _getManager().isAdmin(msg.sender);
+        _;
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @dev Initializes the contract
+    /// @param _vault The vault to deposit into
+    /// @param _manager The PerpManager contract that handles role management
+    function initialize(IWasabiVault _vault, PerpManager _manager) public initializer {
+        __Ownable_init(address(_manager));
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+
+        vault = _vault;
+    }
+    
+    /// @dev Raises the deposit cap and deposits the user's allocation into the vault
+    /// @notice Caller must have been allocated a deposit amount and must have the full amount in their wallet
+    /// @notice This contract must have ADMIN role to raise the deposit cap
+    function deposit() external nonReentrant {
+        // Check if the user is allocated
+        uint256 allocation = depositAllocations[msg.sender];
+        if (allocation == 0) revert SenderNotAllocated();
+        delete depositAllocations[msg.sender];
+
+        // Check if the user has the full allocation in their wallet
+        IERC20 asset = IERC20(vault.asset());
+        if (asset.balanceOf(msg.sender) < allocation) revert InsufficientBalance();
+
+        // Check if the contract has ADMIN role
+        (bool isAdmin, ) = _getManager().hasRole(0, address(this));
+        if (!isAdmin) revert DepositWindowClosed();
+
+        // Increase the deposit cap (this contract must have ADMIN role)
+        uint256 currentDepositCap = vault.maxDeposit(msg.sender) + vault.totalAssets();
+        vault.setDepositCap(currentDepositCap + allocation);
+
+        // Deposit on behalf of the user
+        asset.safeTransferFrom(msg.sender, address(this), allocation);
+        asset.forceApprove(address(vault), allocation);
+        vault.deposit(allocation, msg.sender);
+    }
+
+    /// @dev Sets the allocations for the competition winners
+    /// @param _users The addresses of the competition winners
+    /// @param _allocations The allocations for the competition winners
+    function setAllocations(address[] calldata _users, uint256[] calldata _allocations) external onlyAdmin {
+        uint256 usersLength = _users.length;
+        if (usersLength != _allocations.length) revert AllocationsLengthMismatch();
+
+        for (uint256 i; i < usersLength; ) {
+            depositAllocations[_users[i]] = _allocations[i];
+            unchecked {
+                i++;
+            }
+        }
+    }
+
+    /// @dev Renounces the ADMIN role from the contract
+    /// @notice Once called, the contract will no longer be able to raise the deposit cap
+    function renounceAdmin() external onlyAdmin {
+        _getManager().renounceRole(0, address(this));
+    }
+
+    /// @inheritdoc UUPSUpgradeable
+    function _authorizeUpgrade(address) internal view override onlyAdmin {}
+
+    /// @dev returns the manager of the contract
+    function _getManager() internal view returns (PerpManager) {
+        return PerpManager(owner());
+    }
+}

--- a/test/berachain/berachainFixtures.ts
+++ b/test/berachain/berachainFixtures.ts
@@ -316,6 +316,17 @@ export async function deployBeraLongPool() {
     await blockRewardController.write.setBaseRate([parseEther("1")], {account: owner.account});
     await blockRewardController.write.setRewardRate([parseEther("1")], {account: owner.account});
 
+    const CappedVaultCompetitionDepositor = await hre.ethers.getContractFactory("CappedVaultCompetitionDepositor");
+    const competitionDepositorAddress = 
+        await hre.upgrades.deployProxy(
+            CappedVaultCompetitionDepositor,
+            [vault.address, perpManager.manager.address],
+            { kind: 'uups' }
+        )
+        .then(c => c.waitForDeployment())
+        .then(c => c.getAddress()).then(getAddress);
+    const competitionDepositor = await hre.viem.getContractAt("CappedVaultCompetitionDepositor", competitionDepositorAddress);
+
     return {
         ...vaultFixture,
         ...addressProviderFixture,
@@ -331,7 +342,8 @@ export async function deployBeraLongPool() {
         implAddress,
         ibgt,
         ibgtRewardVault,
-        ibgtInfraredVault
+        ibgtInfraredVault,
+        competitionDepositor
     };
 }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -396,6 +396,17 @@ export async function deployWasabiLongPool() {
     await wasabiLongPool.write.addVault([vault.address], {account: perpManager.vaultAdmin.account});
     await vault.write.depositEth([owner.account.address], { value: parseEther("20") });
 
+    const CappedVaultCompetitionDepositor = await hre.ethers.getContractFactory("CappedVaultCompetitionDepositor");
+    const competitionDepositorAddress = 
+        await hre.upgrades.deployProxy(
+            CappedVaultCompetitionDepositor,
+            [vault.address, perpManager.manager.address],
+            { kind: 'uups' }
+        )
+        .then(c => c.waitForDeployment())
+        .then(c => c.getAddress()).then(getAddress);
+    const competitionDepositor = await hre.viem.getContractAt("CappedVaultCompetitionDepositor", competitionDepositorAddress);
+
     return {
         ...vaultFixture,
         ...addressProviderFixture,
@@ -406,7 +417,8 @@ export async function deployWasabiLongPool() {
         user2,
         publicClient,
         contractName,
-        implAddress
+        implAddress,
+        competitionDepositor
     };
 }
 


### PR DESCRIPTION
Adds a new contract, called CappedVaultCompetitionDepositor, with the following properties:

- Admin should be able to set deposit allocations per address
- Users with allocations should be able to deposit given amount only once
- When users with allocations deposit, contract should raise the deposit cap on the vault and deposit on behalf of the user in one transaction
- Deposit contract itself should have admin role so it can raise the deposit cap
- Contract should have an admin only function that renounces the admin role once all allocations are deposited