### PR TITLE
Change tpsl _orderSignature to bytes

### DIFF
--- a/.openzeppelin/sepolia.json
+++ b/.openzeppelin/sepolia.json
@@ -15622,6 +15622,491 @@
           ]
         }
       }
+    },
+    "79773a454bc095aeb389ad956460bea2c4fc701e7f15eb1e01de2f307690c69b": {
+      "address": "0xD21A50b213867bF1A63860929707d8bE9F2d17c2",
+      "txHash": "0xafbc967c82baea090d056d53e12f3415389b7f8b8138f5c9484e38e604a93208",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "isLongPool",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:29"
+          },
+          {
+            "label": "addressProvider",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_contract(IAddressProvider)28380",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:32"
+          },
+          {
+            "label": "positions",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_uint256,t_bytes32)",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:35"
+          },
+          {
+            "label": "vaults",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_address)",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:38"
+          },
+          {
+            "label": "quoteTokens",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:42",
+            "renamedFrom": "baseTokens"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)4386_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)3521_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)2712_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)4323_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IAddressProvider)28380": {
+            "label": "contract IAddressProvider",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bytes32)": {
+            "label": "mapping(uint256 => bytes32)",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:39",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:41",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:44",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0xD21A50b213867bF1A63860929707d8bE9F2d17c2",
+        "0x4e180F24519266BD99DFf644830b44023ABfeAc7"
+      ]
+    },
+    "807297db02b22a5109dd1988dffa30339f6e52912231a3485b521a1d82c2fbb2": {
+      "address": "0x82c2ea399FF27106107143bC3Bd9330CaB60E7fD",
+      "txHash": "0xf8e7ea81b08290df3df1aa3a46ffcba4964f0b4e9b08a27feb7b3dd102f40fe1",
+      "layout": {
+        "solcVersion": "0.8.26",
+        "storage": [
+          {
+            "label": "isLongPool",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:29"
+          },
+          {
+            "label": "addressProvider",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_contract(IAddressProvider)28380",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:32"
+          },
+          {
+            "label": "positions",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_uint256,t_bytes32)",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:35"
+          },
+          {
+            "label": "vaults",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_address)",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:38"
+          },
+          {
+            "label": "quoteTokens",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "BaseWasabiPool",
+            "src": "contracts/BaseWasabiPool.sol:42",
+            "renamedFrom": "baseTokens"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)4386_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)3521_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)2712_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)4323_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_contract(IAddressProvider)28380": {
+            "label": "contract IAddressProvider",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bytes32)": {
+            "label": "mapping(uint256 => bytes32)",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:39",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:41",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:44",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:40",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0x82c2ea399FF27106107143bC3Bd9330CaB60E7fD",
+        "0x3A76A25CE215A2074DaEb130ea0a972128711AF5",
+        "0xBF78775775eDb531A99590d97Ae0A43f017a2Fe3"
+      ]
     }
   }
 }

--- a/contracts/BaseWasabiPool.sol
+++ b/contracts/BaseWasabiPool.sol
@@ -335,18 +335,19 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
 
         if (_signature.length != 65 && _expectedSigner.code.length == 0) revert IWasabiPerps.InvalidSignature();
 
-        // First try to recover the signer assuming it's an EOA
-        bytes32 r;
-        bytes32 s;
-        uint8 v;
+        // First try to recover the signer if it's an EOA
+        address signer;
         if (_signature.length == 65) {
+            bytes32 r;
+            bytes32 s;
+            uint8 v;
             assembly {
                 r := mload(add(_signature, 32))
                 s := mload(add(_signature, 64))
                 v := byte(0, mload(add(_signature, 96)))
             }
+            signer = ecrecover(typedDataHash, v, r, s);
         }
-        address signer = ecrecover(typedDataHash, v, r, s);
 
         // If the signer is not the expected signer, check if it's an authorized signer
         if (_expectedSigner != signer && !_getManager().isAuthorizedSigner(_expectedSigner, signer)) {

--- a/contracts/BaseWasabiPool.sol
+++ b/contracts/BaseWasabiPool.sol
@@ -339,10 +339,12 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
         bytes32 r;
         bytes32 s;
         uint8 v;
-        assembly {
-            r := mload(add(_signature, 32))
-            s := mload(add(_signature, 64))
-            v := byte(0, mload(add(_signature, 96)))
+        if (_signature.length == 65) {
+            assembly {
+                r := mload(add(_signature, 32))
+                s := mload(add(_signature, 64))
+                v := byte(0, mload(add(_signature, 96)))
+            }
         }
         address signer = ecrecover(typedDataHash, v, r, s);
 

--- a/contracts/BaseWasabiPool.sol
+++ b/contracts/BaseWasabiPool.sol
@@ -337,7 +337,7 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
         // ==================
         // 1. EOA signer validation
         //   1a. Recovered EOA matches the expected signer
-        //   1b. Recovered EOA is an authorized signer, while expected signer might be a contract
+        //   1b. Recovered EOA is authorized to sign for the expected signer, which might be a contract
         // 2. Contract signer (ERC-1271) validation
         // If both cases fail, revert
 

--- a/contracts/IWasabiPerps.sol
+++ b/contracts/IWasabiPerps.sol
@@ -358,7 +358,7 @@ interface IWasabiPerps {
         ClosePositionRequest calldata _request,
         Signature calldata _signature,
         ClosePositionOrder calldata _order,
-        Signature calldata _orderSignature
+        bytes calldata _orderSignature
     ) external payable;
 
     /// @dev Liquidates a position

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -138,7 +138,7 @@ contract WasabiLongPool is BaseWasabiPool {
         ClosePositionRequest calldata _request,
         Signature calldata _signature,
         ClosePositionOrder calldata _order,
-        Signature calldata _orderSignature // signed by trader
+        bytes calldata _orderSignature // signed by trader
     ) external payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
         uint256 id = _request.position.id;
         address trader = _request.position.trader;

--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -135,7 +135,7 @@ contract WasabiShortPool is BaseWasabiPool {
         ClosePositionRequest calldata _request,
         Signature calldata _signature,
         ClosePositionOrder calldata _order,
-        Signature calldata _orderSignature // signed by trader
+        bytes calldata _orderSignature // signed by trader
     ) external payable nonReentrant onlyRole(Roles.LIQUIDATOR_ROLE) {
         uint256 id = _request.position.id;
         if (id != _order.positionId) revert InvalidOrder();

--- a/scripts/sepolia/upgradeWasabiLongPool.ts
+++ b/scripts/sepolia/upgradeWasabiLongPool.ts
@@ -20,14 +20,6 @@ async function main() {
       WasabiLongPool,
       {
         redeployImplementation: 'always',
-        // call: {
-        //   fn: "migrateFees",
-        //   args: [
-        //     ["0x6400c43e5dd1f713fd623d92dc64831dd12d3298", "0x92ea09e6f1cc933baac19cd6414b64a9d84cc135"], 
-        //     [12300000263809366n, 226470503n],
-        //     [12941153986961836488n, 3291553456n]
-        //   ]
-        // }
       }
     )
     .then(c => c.waitForDeployment())

--- a/scripts/sepolia/upgradeWasabiShortPool.ts
+++ b/scripts/sepolia/upgradeWasabiShortPool.ts
@@ -7,10 +7,10 @@ async function main() {
   const currentAddress = getAddress(CONFIG.shortPool);
   const WasabiShortPool = await hre.ethers.getContractFactory("WasabiShortPool");
 
-  await hre.upgrades.forceImport(
-    CONFIG.shortPool,
-    WasabiShortPool
-  )
+  // await hre.upgrades.forceImport(
+  //   CONFIG.shortPool,
+  //   WasabiShortPool
+  // )
 
   console.log("1. Upgrading WasabiShortPool...");
   const address =
@@ -19,14 +19,6 @@ async function main() {
       WasabiShortPool,
       {
         redeployImplementation: 'always',
-        // call: {
-        //   fn: "migrateFees",
-        //   args: [
-        //     ["0x6400c43e5dd1f713fd623d92dc64831dd12d3298", "0x92ea09e6f1cc933baac19cd6414b64a9d84cc135"], 
-        //     [2750000000000000n, 10620994n],
-        //     [693263597109332504n, 2280378565n]
-        //   ]
-        // }
       }
     )
     .then(c => c.waitForDeployment())

--- a/test/WasabiLongPool_tpslFlow.test.ts
+++ b/test/WasabiLongPool_tpslFlow.test.ts
@@ -2,7 +2,7 @@ import {
     time,
     loadFixture,
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
-import { getAddress, parseEther, zeroAddress } from "viem";
+import { getAddress, parseEther, parseSignature, zeroAddress } from "viem";
 import { expect } from "chai";
 import { AddCollateralRequest, ClosePositionRequest, FunctionCallData, getEventPosition, OpenPositionRequest, OrderType, PayoutType } from "./utils/PerpStructUtils";
 import { deployLongPoolMockEnvironment } from "./fixtures";
@@ -715,9 +715,15 @@ describe("WasabiLongPool - TP/SL Flow Test", function () {
 
                 // Try to Close Position
                 const { request } = await createSignedClosePositionRequest({position});
+                const orderSignatureData = parseSignature(orderSignature);
+                const signature = {
+                    v: Number(orderSignatureData.v),
+                    r: orderSignatureData.r,
+                    s: orderSignatureData.s,
+                }
 
                 await expect(wasabiLongPool.write.closePosition(
-                    [PayoutType.UNWRAPPED, request, orderSignature, order, orderSignature], {account: liquidator.account} // Wrong signature
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account} // Wrong signature
                 )).to.be.rejectedWith("InvalidSignature");
             });
 

--- a/test/WasabiShortPool_tpslFlow.test.ts
+++ b/test/WasabiShortPool_tpslFlow.test.ts
@@ -2,7 +2,7 @@ import {
     time,
     loadFixture,
 } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
-import {encodeFunctionData, zeroAddress, parseEther, getAddress} from "viem";
+import {encodeFunctionData, zeroAddress, parseEther, getAddress, parseSignature} from "viem";
 import { expect } from "chai";
 import { Position, OrderType, PayoutType, getValueWithoutFee, ClosePositionRequest, FunctionCallData, OpenPositionRequest, AddCollateralRequest, getEventPosition } from "./utils/PerpStructUtils";
 import { getApproveAndSwapFunctionCallData, getApproveAndSwapFunctionCallDataExact } from "./utils/SwapUtils";
@@ -686,9 +686,15 @@ describe("WasabiShortPool - TP/SL Flow Test", function () {
 
                 // Try to Close Position
                 const { request } = await createSignedClosePositionRequest({position});
+                const orderSignatureData = parseSignature(orderSignature);
+                const signature = {
+                    v: Number(orderSignatureData.v),
+                    r: orderSignatureData.r,
+                    s: orderSignatureData.s,
+                }
 
                 await expect(wasabiShortPool.write.closePosition(
-                    [PayoutType.UNWRAPPED, request, orderSignature, order, orderSignature], {account: liquidator.account}
+                    [PayoutType.UNWRAPPED, request, signature, order, orderSignature], {account: liquidator.account}
                 )).to.be.rejectedWith("InvalidSignature");
             });
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -3,7 +3,7 @@ import type { Address } from 'abitype'
 import hre from "hardhat";
 import { expect } from "chai";
 import { parseEther, zeroAddress, getAddress, maxUint256, encodeFunctionData, parseUnits, EncodeFunctionDataReturnType, Account, toFunctionSelector, GetContractReturnType } from "viem";
-import { ClosePositionRequest, ClosePositionOrder, OrderType, FunctionCallData, OpenPositionRequest, Position, Vault, WithSignature, getEventPosition, getFee, getEmptyPosition } from "./utils/PerpStructUtils";
+import { ClosePositionRequest, ClosePositionOrder, OrderType, FunctionCallData, OpenPositionRequest, Position, Vault, WithSignature, getEventPosition, getFee, getEmptyPosition, WithSignatureHex } from "./utils/PerpStructUtils";
 import { Signer, signClosePositionRequest, signClosePositionOrder, signOpenPositionRequest } from "./utils/SigningUtils";
 import { getApproveAndSwapExactlyOutFunctionCallData, getApproveAndSwapFunctionCallData, getRouterSwapExactlyOutFunctionCallData, getRouterSwapFunctionCallData, getSwapExactlyOutFunctionCallData, getSwapFunctionCallData, getSweepTokenWithFeeCallData, getUnwrapWETH9WithFeeCallData } from "./utils/SwapUtils";
 import { WETHAbi } from "./utils/WETHAbi";
@@ -315,7 +315,7 @@ export async function deployLongPoolMockEnvironment() {
         return order;
     }
 
-    const createSignedClosePositionOrder = async (params: CreateClosePositionOrderParams): Promise<WithSignature<ClosePositionOrder>> => {
+    const createSignedClosePositionOrder = async (params: CreateClosePositionOrderParams): Promise<WithSignatureHex<ClosePositionOrder>> => {
         const {traderSigner} = params;
         const order = await createClosePositionOrder(params);
         const signature = await signClosePositionOrder(traderSigner, contractName, wasabiLongPool.address, order);
@@ -900,7 +900,7 @@ export async function deployShortPoolMockEnvironment() {
         return order;
     }
 
-    const createSignedClosePositionOrder = async (params: CreateClosePositionOrderParams): Promise<WithSignature<ClosePositionOrder>> => {
+    const createSignedClosePositionOrder = async (params: CreateClosePositionOrderParams): Promise<WithSignatureHex<ClosePositionOrder>> => {
         const {traderSigner} = params;
         const order = await createClosePositionOrder(params);
         const signature = await signClosePositionOrder(traderSigner, contractName, wasabiShortPool.address, order);

--- a/test/utils/PerpStructUtils.ts
+++ b/test/utils/PerpStructUtils.ts
@@ -1,6 +1,6 @@
 import { time } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import type { Address } from 'abitype'
-import {formatEther, zeroAddress} from "viem";
+import {formatEther, Hex, zeroAddress} from "viem";
 import { Signature } from "./SigningUtils";
 
 export enum OrderType {
@@ -18,6 +18,11 @@ export enum PayoutType {
 export type WithSignature<T> = {
   request: T;
   signature: Signature;
+}
+
+export type WithSignatureHex<T> = {
+  request: T;
+  signature: Hex;
 }
 
 export type FunctionCallData = {

--- a/test/utils/SigningUtils.ts
+++ b/test/utils/SigningUtils.ts
@@ -257,7 +257,7 @@ export async function signClosePositionOrder(
   contractName: string,
   verifyingContract: Address, 
   order: ClosePositionOrder
-): Promise<Signature> {
+): Promise<Hex> {
   const domain = getDomainData(contractName, verifyingContract);
   const typeData: EIP712SignatureParams<ClosePositionOrder>  = {
     account: signer.account.address,
@@ -269,11 +269,5 @@ export async function signClosePositionOrder(
     message: order,
   };
 
-  const signature = await signer.signTypedData(typeData);
-  const signatureData = parseSignature(signature);
-  return {
-    v: Number(signatureData.v),
-    r: signatureData.r,
-    s: signatureData.s,
-  };
+  return await signer.signTypedData(typeData);
 }


### PR DESCRIPTION
Switch `orderSignature` from `IWasabiPerps.Signature` to `bytes` so we can execute TP/SL orders signed by Coinbase smart wallets, which are not the typical 65 bytes in length.