### PR TITLE
Remove requirement that request.id == existingPosition.id

### DIFF
--- a/contracts/BaseWasabiPool.sol
+++ b/contracts/BaseWasabiPool.sol
@@ -218,7 +218,7 @@ abstract contract BaseWasabiPool is IWasabiPerps, UUPSUpgradeable, OwnableUpgrad
         address currency = _request.currency;
         address collateralCurrency = _request.targetCurrency;
         if (existingPosition.id != 0) {
-            if (positions[_request.id] != existingPosition.hash()) revert InvalidPosition();
+            if (positions[existingPosition.id] != existingPosition.hash()) revert InvalidPosition();
             if (currency != existingPosition.currency) revert InvalidCurrency();
             if (collateralCurrency != existingPosition.collateralCurrency) revert InvalidTargetCurrency();
         } else {

--- a/contracts/WasabiLongPool.sol
+++ b/contracts/WasabiLongPool.sol
@@ -433,9 +433,10 @@ contract WasabiLongPool is BaseWasabiPool {
         uint256 _collateralAmount
     ) internal returns (Position memory) {
         bool isEdit = _request.existingPosition.id != 0;
+        uint256 id = isEdit ? _request.existingPosition.id : _request.id;
 
         Position memory position = Position(
-            _request.id,
+            id,
             _trader,
             _request.currency,
             _request.targetCurrency,
@@ -446,11 +447,11 @@ contract WasabiLongPool is BaseWasabiPool {
             _request.existingPosition.feesToBePaid + _request.fee
         );
 
-        positions[_request.id] = position.hash();
+        positions[id] = position.hash();
 
         if (isEdit) {
             emit PositionIncreased(
-                _request.id, 
+                id, 
                 _trader,
                 _request.downPayment, 
                 _request.principal, 
@@ -459,7 +460,7 @@ contract WasabiLongPool is BaseWasabiPool {
             );
         } else {
             emit PositionOpened(
-                _request.id,
+                id,
                 _trader,
                 _request.currency,
                 _request.targetCurrency,

--- a/contracts/WasabiShortPool.sol
+++ b/contracts/WasabiShortPool.sol
@@ -466,9 +466,10 @@ contract WasabiShortPool is BaseWasabiPool {
         uint256 _amountSpent
     ) internal returns (Position memory) {
         bool isEdit = _request.existingPosition.id != 0;
+        uint256 id = isEdit ? _request.existingPosition.id : _request.id;
 
         Position memory position = Position(
-            _request.id,
+            id,
             _trader,
             _request.currency,
             _request.targetCurrency,
@@ -479,11 +480,11 @@ contract WasabiShortPool is BaseWasabiPool {
             _request.existingPosition.feesToBePaid + _request.fee
         );
 
-        positions[_request.id] = position.hash();
+        positions[id] = position.hash();
 
         if (isEdit) {
             emit PositionIncreased(
-                _request.id, 
+                id, 
                 _trader,
                 _request.downPayment, 
                 _amountSpent, 
@@ -492,7 +493,7 @@ contract WasabiShortPool is BaseWasabiPool {
             );
         } else {
             emit PositionOpened(
-                _request.id,
+                id,
                 _trader,
                 _request.currency,
                 _request.targetCurrency,

--- a/test/WasabiLongPool_validations.test.ts
+++ b/test/WasabiLongPool_validations.test.ts
@@ -232,35 +232,6 @@ describe("WasabiLongPool - Validations Test", function () {
 
     describe("Edit Position Validations", function () {
         describe("Increase Position", function () {
-            it("InvalidPosition - request.id != request.existingPosition.id", async function () {
-                const { wasabiLongPool, mockSwap, wethAddress, uPPG, user1, totalAmountIn, totalSize, initialPrice, priceDenominator, orderSigner, contractName, sendDefaultOpenPositionRequest } = await loadFixture(deployLongPoolMockEnvironment);
-
-                // Open Position
-                const {position} = await sendDefaultOpenPositionRequest();
-
-                await time.increase(86400n); // 1 day later
-
-                const functionCallDataList: FunctionCallData[] =
-                    getApproveAndSwapFunctionCallData(mockSwap.address, wethAddress, uPPG.address, totalSize);
-                const openPositionRequest: OpenPositionRequest = {
-                    id: position.id + 1n, // Incorrect ID
-                    currency: position.currency,
-                    targetCurrency: position.collateralCurrency,
-                    downPayment: position.downPayment,
-                    principal: position.principal,
-                    minTargetAmount: totalSize * initialPrice / priceDenominator,
-                    expiration: BigInt(await time.latest()) + 86400n,
-                    fee: position.feesToBePaid,
-                    functionCallDataList,
-                    existingPosition: position,
-                    referrer: zeroAddress
-                };
-                const signature = await signOpenPositionRequest(orderSigner, contractName, wasabiLongPool.address, openPositionRequest);
-
-                await expect(wasabiLongPool.write.openPosition([openPositionRequest, signature], { value: totalAmountIn, account: user1.account }))
-                    .to.be.rejectedWith("InvalidPosition", "Cannot increase position with different position ID");
-            });
-
             it("InvalidPosition - stored hash != request.existingPosition.hash", async function () {
                 const { wasabiLongPool, mockSwap, wethAddress, uPPG, user1, totalAmountIn, totalSize, initialPrice, priceDenominator, orderSigner, contractName, sendDefaultOpenPositionRequest } = await loadFixture(deployLongPoolMockEnvironment);
 

--- a/test/WasabiRouter.test.ts
+++ b/test/WasabiRouter.test.ts
@@ -132,7 +132,7 @@ describe("WasabiRouter", function () {
             }
             const traderSignature1 = await signOpenPositionRequestBytes(user1, "WasabiRouter", wasabiRouter.address, traderRequest1);
             const traderRequest2: OpenPositionRequest = {
-                id: 1n,
+                id: 2n,
                 currency: usdc.address,
                 targetCurrency: weth.address,
                 downPayment,
@@ -308,7 +308,7 @@ describe("WasabiRouter", function () {
             }
             const traderSignature1 = await signOpenPositionRequestBytes(user1, "WasabiRouter", wasabiRouter.address, traderRequest1);
             const traderRequest2: OpenPositionRequest = {
-                id: 1n,
+                id: 2n,
                 currency: weth.address,
                 targetCurrency: usdc.address,
                 downPayment,
@@ -360,6 +360,7 @@ describe("WasabiRouter", function () {
             );
             const increaseEvents = await wasabiShortPool.getEvents.PositionIncreased();
             expect(increaseEvents).to.have.lengthOf(1);
+            expect(increaseEvents[0].args.id).to.equal(position.id);
         });
 
         it("Short Position w/ Authorized Signer", async function () {

--- a/test/WasabiShortPool_validations.test.ts
+++ b/test/WasabiShortPool_validations.test.ts
@@ -111,35 +111,6 @@ describe("WasabiShortPool - Validations Test", function () {
 
     describe("Edit Position Validations", function () {
         describe("Increase Position", function () {
-            it("InvalidPosition - request.id != request.existingPosition.id", async function () {
-                const { wasabiShortPool, mockSwap, wethAddress, uPPG, user1, totalAmountIn, principal, initialPPGPrice, priceDenominator, orderSigner, contractName, sendDefaultOpenPositionRequest } = await loadFixture(deployShortPoolMockEnvironment);
-                
-                // Open Position
-                const {position} = await sendDefaultOpenPositionRequest();
-
-                await time.increase(86400n); // 1 day later
-
-                const functionCallDataList: FunctionCallData[] =
-                    getApproveAndSwapFunctionCallData(mockSwap.address, uPPG.address, wethAddress, principal);
-                const openPositionRequest: OpenPositionRequest = {
-                    id: position.id + 1n, // Incorrect ID
-                    currency: position.currency,
-                    targetCurrency: position.collateralCurrency,
-                    downPayment: position.downPayment,
-                    principal: position.principal,
-                    minTargetAmount: principal * initialPPGPrice / priceDenominator,
-                    expiration: BigInt(await time.latest()) + 86400n,
-                    fee: position.feesToBePaid,
-                    functionCallDataList,
-                    existingPosition: position,
-                    referrer: zeroAddress
-                };
-                const signature = await signOpenPositionRequest(orderSigner, contractName, wasabiShortPool.address, openPositionRequest);
-
-                await expect(wasabiShortPool.write.openPosition([openPositionRequest, signature], { value: totalAmountIn, account: user1.account }))
-                    .to.be.rejectedWith("InvalidPosition", "Cannot increase position with different position ID");
-            });
-
             it("InvalidPosition - stored hash != request.existingPosition.hash", async function () {
                 const { wasabiShortPool, mockSwap, wethAddress, uPPG, user1, totalAmountIn, principal, initialPPGPrice, priceDenominator, orderSigner, contractName, sendDefaultOpenPositionRequest } = await loadFixture(deployShortPoolMockEnvironment);
                 


### PR DESCRIPTION
Now, when an `existingPosition` struct is provided in the `OpenPositionRequest`, the `request.id` is ignored and `request.existingPosition.id` is used instead. This way, a user can sign two different limit orders with different ids in the requests, and once the first order is used to open a position, the second can be submitted later with that position as the `existingPosition` to add to it instead of opening another new position.